### PR TITLE
Upward Propagation fixes in VtxTreeView

### DIFF
--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -253,8 +253,14 @@ const treeReducer = (
       if (!action.controlled && state.disabledIds.has(action.id)) return state;
       const selectedIds = new Set<number>(state.selectedIds);
       selectedIds.delete(action.id);
-      const halfSelectedIds = new Set<number>(state.halfSelectedIds);
-      halfSelectedIds.delete(action.id);
+      let halfSelectedIds;
+      if (action.multiSelect) {
+        halfSelectedIds = new Set<number>(state.halfSelectedIds);
+        halfSelectedIds.delete(action.id);
+      } else {
+        halfSelectedIds = new Set<number>();
+      }
+
       return {
         ...state,
         selectedIds,
@@ -622,7 +628,8 @@ const useTree = ({
         idsToUpdate,
         selectedIds,
         disabledIds,
-        halfSelectedIds
+        halfSelectedIds,
+        multiSelect
       );
       for (const id of every) {
         if (!selectedIds.has(id)) {

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -621,7 +621,8 @@ const useTree = ({
         data,
         idsToUpdate,
         selectedIds,
-        disabledIds
+        disabledIds,
+        halfSelectedIds
       );
       for (const id of every) {
         if (!selectedIds.has(id)) {

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -1053,9 +1053,20 @@ const Node = (props: INodeProps) => {
         lastInteractedWith: element.id,
       });
     } else if (event.ctrlKey || clickActions.select) {
+      const isSelectedAndHasSelectedDescendants =
+        isBranchNode(data, element.id) &&
+        selectedIds.has(element.id) &&
+        [...getDescendants(data, element.id, new Set<number>())].some((item) =>
+          [...selectedIds].includes(item)
+        );
+
       //Select
       dispatch({
-        type: togglableSelect ? treeTypes.toggleSelect : treeTypes.select,
+        type: togglableSelect
+          ? isSelectedAndHasSelectedDescendants
+            ? treeTypes.halfSelect
+            : treeTypes.toggleSelect
+          : treeTypes.select,
         id: element.id,
         multiSelect,
         lastInteractedWith: element.id,
@@ -1489,8 +1500,19 @@ const handleKeyDown = ({
     case " ":
     case "Spacebar":
       event.preventDefault();
+      const isSelectedAndHasSelectedDescendants =
+        isBranchNode(data, element.id) &&
+        selectedIds.has(element.id) &&
+        [...getDescendants(data, element.id, new Set<number>())].some((item) =>
+          [...selectedIds].includes(item)
+        );
+
       dispatch({
-        type: togglableSelect ? treeTypes.toggleSelect : treeTypes.select,
+        type: togglableSelect
+          ? isSelectedAndHasSelectedDescendants
+            ? treeTypes.halfSelect
+            : treeTypes.toggleSelect
+          : treeTypes.select,
         id: id,
         multiSelect,
         lastInteractedWith: id,

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -250,13 +250,8 @@ const treeReducer = (
     }
     case treeTypes.deselect: {
       if (!action.controlled && state.disabledIds.has(action.id)) return state;
-      let selectedIds;
-      if (action.multiSelect) {
-        selectedIds = new Set<number>(state.selectedIds);
-        selectedIds.delete(action.id);
-      } else {
-        selectedIds = new Set<number>();
-      }
+      const selectedIds = new Set<number>(state.selectedIds);
+      selectedIds.delete(action.id);
       const halfSelectedIds = new Set<number>(state.halfSelectedIds);
       halfSelectedIds.delete(action.id);
       return {
@@ -610,7 +605,7 @@ const useTree = ({
 
   //Update parent if a child changes
   useEffect(() => {
-    if (propagateSelectUpwards && multiSelect) {
+    if (propagateSelectUpwards) {
       const idsToUpdate = new Set<number>(toggledIds);
       if (
         lastInteractedWith &&

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -21,6 +21,7 @@ import {
   symmetricDifference,
   usePrevious,
   usePreviousData,
+  isBranchSelectedAndHasSelectedDescendants,
 } from "./utils";
 
 export interface INode {
@@ -1048,12 +1049,11 @@ const Node = (props: INodeProps) => {
         lastInteractedWith: element.id,
       });
     } else if (event.ctrlKey || clickActions.select) {
-      const isSelectedAndHasSelectedDescendants =
-        isBranchNode(data, element.id) &&
-        selectedIds.has(element.id) &&
-        [...getDescendants(data, element.id, new Set<number>())].some((item) =>
-          [...selectedIds].includes(item)
-        );
+      const isSelectedAndHasSelectedDescendants = isBranchSelectedAndHasSelectedDescendants(
+        data,
+        element.id,
+        selectedIds
+      );
 
       //Select
       dispatch({
@@ -1495,12 +1495,11 @@ const handleKeyDown = ({
     case " ":
     case "Spacebar":
       event.preventDefault();
-      const isSelectedAndHasSelectedDescendants =
-        isBranchNode(data, element.id) &&
-        selectedIds.has(element.id) &&
-        [...getDescendants(data, element.id, new Set<number>())].some((item) =>
-          [...selectedIds].includes(item)
-        );
+      const isSelectedAndHasSelectedDescendants = isBranchSelectedAndHasSelectedDescendants(
+        data,
+        element.id,
+        selectedIds
+      );
 
       dispatch({
         type: togglableSelect

--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -200,9 +200,12 @@ export const propagateSelectChange = (
           selectedIds.has(x) || changes.some.has(x) || halfSelectedIds.has(x)
       );
       if (!some) {
-        const allAncestors = getAncestors(data, currentId, disabledIds);
-        const selectedAncestorId = [...selectedIds].find((id) => {
-          return allAncestors.includes(id);
+        const selectedAncestorId = getAncestors(
+          data,
+          currentId,
+          disabledIds
+        ).find((id) => {
+          return selectedIds.has(id);
         });
         if (!multiSelect && selectedAncestorId) {
           const descendants = getDescendants(
@@ -367,8 +370,8 @@ export const isBranchSelectedAndHasSelectedDescendants = (
   return (
     isBranchNode(data, elementId) &&
     selectedIds.has(elementId) &&
-    [...getDescendants(data, elementId, new Set<number>())].some((item) =>
-      [...selectedIds].includes(item)
+    getDescendants(data, elementId, new Set<number>()).some((item) =>
+      selectedIds.has(item)
     )
   );
 };

--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -171,8 +171,7 @@ export const propagateSelectChange = (
       );
       if (enabledChildren.length === 0) break;
       const some = enabledChildren.some(
-        (x) =>
-          selectedIds.has(x) || changes.some.has(x)
+        (x) => selectedIds.has(x) || changes.some.has(x)
       );
       if (!some) {
         changes.none.add(parent);
@@ -316,4 +315,18 @@ export const onComponentBlur = (
   } else {
     !treeNode.contains(event.nativeEvent.relatedTarget as Node) && callback();
   }
+};
+
+export const isBranchSelectedAndHasSelectedDescendants = (
+  data: INode[],
+  elementId: number,
+  selectedIds: Set<number>
+) => {
+  return (
+    isBranchNode(data, elementId) &&
+    selectedIds.has(elementId) &&
+    [...getDescendants(data, elementId, new Set<number>())].some((item) =>
+      [...selectedIds].includes(item)
+    )
+  );
 };

--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -148,7 +148,8 @@ export const propagateSelectChange = (
   data: INode[],
   ids: Set<number>,
   selectedIds: Set<number>,
-  disabledIds: Set<number>
+  disabledIds: Set<number>,
+  halfSelectedIds: Set<number>
 ) => {
   const changes = {
     every: new Set<number>(),
@@ -171,7 +172,8 @@ export const propagateSelectChange = (
       );
       if (enabledChildren.length === 0) break;
       const some = enabledChildren.some(
-        (x) => selectedIds.has(x) || changes.some.has(x)
+        (x) =>
+          selectedIds.has(x) || changes.some.has(x) || halfSelectedIds.has(x)
       );
       if (!some) {
         changes.none.add(parent);

--- a/src/__tests__/CheckboxTree.test.tsx
+++ b/src/__tests__/CheckboxTree.test.tsx
@@ -48,10 +48,12 @@ const folder = {
 
 const data = flattenTree(folder);
 
-function MultiSelectCheckbox({
+function CheckboxTree({
   propagateSelect = true,
+  multiSelect = true,
 }: {
   propagateSelect?: boolean;
+  multiSelect?: boolean;
 }) {
   return (
     <div>
@@ -59,7 +61,7 @@ function MultiSelectCheckbox({
         <TreeView
           data={data}
           aria-label="Checkbox tree"
-          multiSelect
+          multiSelect={multiSelect}
           propagateSelect={propagateSelect}
           propagateSelectUpwards
           togglableSelect
@@ -94,7 +96,7 @@ function MultiSelectCheckbox({
 }
 
 test("Shift + Up / Down Arrow", () => {
-  const { queryAllByRole } = render(<MultiSelectCheckbox />);
+  const { queryAllByRole } = render(<CheckboxTree />);
 
   const nodes = queryAllByRole("treeitem");
   nodes[0].focus();
@@ -109,7 +111,7 @@ test("Shift + Up / Down Arrow", () => {
 });
 
 test("Shift + Up / Down Arrow", () => {
-  const { queryAllByRole } = render(<MultiSelectCheckbox />);
+  const { queryAllByRole } = render(<CheckboxTree />);
 
   const nodes = queryAllByRole("treeitem");
   nodes[0].focus();
@@ -124,7 +126,7 @@ test("Shift + Up / Down Arrow", () => {
 });
 
 test("propagateselect selects all child nodes", () => {
-  const { queryAllByRole, container } = render(<MultiSelectCheckbox />);
+  const { queryAllByRole, container } = render(<CheckboxTree />);
   const nodes = queryAllByRole("treeitem");
   nodes[0].focus();
   if (document.activeElement == null)
@@ -140,7 +142,7 @@ test("propagateselect selects all child nodes", () => {
 });
 
 test("expect when nodeAction='check', aria-multiselectable is not set and aria-checked is set", () => {
-  const { queryAllByRole } = render(<MultiSelectCheckbox />);
+  const { queryAllByRole } = render(<CheckboxTree />);
   const treeNodes = queryAllByRole("tree");
   expect(treeNodes[0]).not.toHaveAttribute("aria-multiselectable");
 
@@ -149,7 +151,7 @@ test("expect when nodeAction='check', aria-multiselectable is not set and aria-c
 });
 
 test("expect when nodeAction='check', parent node indeterminate's state is set when a children node is checked ", () => {
-  const { queryAllByRole } = render(<MultiSelectCheckbox />);
+  const { queryAllByRole } = render(<CheckboxTree />);
   const nodes = queryAllByRole("treeitem");
   nodes[0].focus();
   if (document.activeElement == null)
@@ -163,8 +165,32 @@ test("expect when nodeAction='check', parent node indeterminate's state is set w
   expect(nodes[0]).toHaveAttribute("aria-checked", "mixed");
 });
 
-test("propagateselectupwards half-selects all parent nodes", () => {
-  const { queryAllByRole, container } = render(<MultiSelectCheckbox />);
+test("propagateselectupwards half-selects all parent nodes in multiselect", () => {
+  const { queryAllByRole, container } = render(<CheckboxTree />);
+  const nodes = queryAllByRole("treeitem");
+  nodes[1].focus();
+  if (document.activeElement == null)
+    throw new Error(
+      `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
+    );
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Drinks
+  fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); //Drinks group
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Apple Juice
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Chocolate
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Coffee
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Tea
+  fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); //Tea group
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Black Tea
+  fireEvent.keyDown(document.activeElement, { key: "Enter" });
+
+  const nodeLevel3Parents = container.querySelectorAll(".half-selected");
+  expect(nodeLevel3Parents.length).toBe(2);
+});
+
+test("propagateselectupwards half-selects all parent nodes in single select", () => {
+  const { queryAllByRole, container } = render(
+    <CheckboxTree multiSelect={false} />
+  );
   const nodes = queryAllByRole("treeitem");
   nodes[1].focus();
   if (document.activeElement == null)
@@ -187,7 +213,7 @@ test("propagateselectupwards half-selects all parent nodes", () => {
 
 test("propagateselectdownwards parent with selected descendants should be half-selected or checked", () => {
   const { queryAllByRole, container } = render(
-    <MultiSelectCheckbox propagateSelect={false} />
+    <CheckboxTree propagateSelect={false} />
   );
   const nodes = queryAllByRole("treeitem");
   nodes[1].focus();
@@ -211,7 +237,7 @@ test("propagateselectdownwards parent with selected descendants should be half-s
 });
 
 test("should have the correct setsize and posinset values", async () => {
-  const { queryAllByRole } = render(<MultiSelectCheckbox />);
+  const { queryAllByRole } = render(<CheckboxTree />);
   const nodes = queryAllByRole("treeitem");
   nodes[0].focus();
   if (document.activeElement == null)

--- a/src/__tests__/CheckboxTree.test.tsx
+++ b/src/__tests__/CheckboxTree.test.tsx
@@ -165,7 +165,7 @@ test("expect when nodeAction='check', parent node indeterminate's state is set w
   expect(nodes[0]).toHaveAttribute("aria-checked", "mixed");
 });
 
-test("propagateselectupwards half-selects all parent nodes in multiselect", () => {
+test("propagateSelectUpwards half-selects all parent nodes in multiselect", () => {
   const { queryAllByRole, container } = render(<CheckboxTree />);
   const nodes = queryAllByRole("treeitem");
   nodes[1].focus();
@@ -187,7 +187,7 @@ test("propagateselectupwards half-selects all parent nodes in multiselect", () =
   expect(nodeLevel3Parents.length).toBe(2);
 });
 
-test("propagateselectupwards half-selects all parent nodes in single select", () => {
+test("propagateSelectUpwards works correctly in single select", () => {
   const { queryAllByRole, container } = render(
     <CheckboxTree multiSelect={false} />
   );
@@ -197,21 +197,32 @@ test("propagateselectupwards half-selects all parent nodes in single select", ()
     throw new Error(
       `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
     );
-  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Drinks
-  fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); //Drinks group
-  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Apple Juice
-  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Chocolate
-  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Coffee
-  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Tea
-  fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); //Tea group
-  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Black Tea
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Drinks
+  fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); // Drinks group
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Apple Juice
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Chocolate
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Coffee
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Tea
+  fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); // Tea group
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Black Tea
   fireEvent.keyDown(document.activeElement, { key: "Enter" });
 
-  const nodeLevel3Parents = container.querySelectorAll(".half-selected");
-  expect(nodeLevel3Parents.length).toBe(2);
+  expect(container.querySelectorAll("[aria-checked='true']").length).toBe(1); // Black Tea
+  expect(container.querySelectorAll(".half-selected").length).toBe(2); // Drinks, Tea
+
+  //After selecting 1st level parent (Drinks) it should unselect 2nd (Tea) and 3rd level (Black Tea)
+  fireEvent.keyDown(document.activeElement, { key: "ArrowLeft" }); // Tea
+  fireEvent.keyDown(document.activeElement, { key: "ArrowLeft" }); // Tea collapsed
+  fireEvent.keyDown(document.activeElement, { key: "ArrowLeft" }); // Drinks group
+  fireEvent.keyDown(document.activeElement, { key: "ArrowLeft" }); // Drinks
+  fireEvent.keyDown(document.activeElement, { key: "Enter" });
+
+  expect(nodes[1]).toHaveAttribute("aria-checked", "true");
+  expect(container.querySelectorAll("[aria-checked='true']").length).toBe(1);
+  expect(container.querySelectorAll(".half-selected").length).toBe(0);
 });
 
-test("propagateselectdownwards parent with selected descendants should be half-selected or checked", () => {
+test("parent with selected descendants should be half-selected or checked in multiselect with propagateSelect={false}", () => {
   const { queryAllByRole, container } = render(
     <CheckboxTree propagateSelect={false} />
   );
@@ -221,19 +232,29 @@ test("propagateselectdownwards parent with selected descendants should be half-s
     throw new Error(
       `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
     );
-  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Drinks
-  fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); //Drinks group
-  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); //Apple Juice
-  fireEvent.keyDown(document.activeElement, { key: "Enter" }); // Apple Juice
-  expect(container.querySelectorAll(".half-selected").length).toBe(1);
-
-  fireEvent.keyDown(document.activeElement, { key: "ArrowLeft" }); //Drinks
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Drinks
+  fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); // Drinks group
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Apple Juice
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Chocolate
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Coffee
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Tea
+  fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); // Tea group
+  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Black Tea
   fireEvent.keyDown(document.activeElement, { key: "Enter" });
-  expect(nodes[1]).toHaveAttribute("aria-checked", "true");
-  expect(container.querySelectorAll(".half-selected").length).toBe(0);
 
-  fireEvent.keyDown(document.activeElement, { key: "Enter" }); //Drinks
-  expect(container.querySelectorAll(".half-selected").length).toBe(1);
+  expect(container.querySelectorAll("[aria-checked='true']").length).toBe(1); // Black Tea
+  expect(container.querySelectorAll(".half-selected").length).toBe(2); // Drinks, Tea
+
+  fireEvent.keyDown(document.activeElement, { key: "ArrowLeft" }); // Tea
+  fireEvent.keyDown(document.activeElement, { key: "Enter" });
+
+  expect(container.querySelectorAll("[aria-checked='true']").length).toBe(2); // Black Tea, Tea
+  expect(container.querySelectorAll(".half-selected").length).toBe(1); // Drinks
+
+  fireEvent.keyDown(document.activeElement, { key: "Enter" }); // Tea
+
+  expect(container.querySelectorAll("[aria-checked='true']").length).toBe(1); // Black Tea
+  expect(container.querySelectorAll(".half-selected").length).toBe(2); // Drinks, Tea
 });
 
 test("should have the correct setsize and posinset values", async () => {


### PR DESCRIPTION
Fixes: 
- if propagateselect is disabled, parent with selected descendants should be half-selected or checked, but not unchecked
- if upward select propagation is enabled, half selected state should propagate upward for single selects.

Ref: UIEN-3764