### PR TITLE
Spread the ITreeNode in flattenTreeHelper, in case of additional props…

### DIFF
--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -287,6 +287,7 @@ export const flattenTree = function(tree: ITreeNode): TreeViewData {
 
   const flattenTreeHelper = function(tree: ITreeNode, parent: NodeId | null) {
     const node: INode = {
+      ...tree,
       id: tree.id || internalCount,
       name: tree.name,
       children: [],


### PR DESCRIPTION
Spread the ITreeNode in flattenTreeHelper, in case of additional properties available on the tree, used while rendering the node...

The original tree might contain additional meta-data, like the icon, which can now be used in the nodeRenderer method