### PR TITLE
Add onNodeSelect callback that triggers on manual node interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A react component that implements the treeview pattern as described by the [WAI-
 | `data`                   | `array[node]` | `required`    | Tree data                                                                                                                                                                 |
 | `nodeRenderer`           | `func`        | `required`    | Render prop for the node (see below for more details)                                                                                                                     |
 | `onSelect`               | `func`        | `noop`        | Function called when a node changes its selected state                                                                                                                    |
+| `onNodeSelect`           | `func`        | `noop`        | Function called when a node was manually selected/deselected                                                                                                              |
 | `onExpand`               | `func`        | `noop`        | Function called when a node changes its expanded state                                                                                                                    |
 | `className`              | `string`      | `""`          | className to add to the outermost dom element, al `ul` with `role = "tree"`                                                                                               |
 | `multiSelect`            | `bool`        | `false`       | Allows multiple nodes to be selected                                                                                                                                      |
@@ -72,7 +73,7 @@ const data = [
 ];
 ```
 
-The array can also be generated from a nested object using the `flattenTree` helper (see the examples below). 
+The array can also be generated from a nested object using the `flattenTree` helper (see the examples below).
 
 Data supports non-sequential ids provided by user.
 
@@ -104,6 +105,11 @@ Data supports non-sequential ids provided by user.
 ## onSelect
 
 - _Arguments_: `onSelect({element, isBranch, isExpanded, isSelected, isHalfSelected, isDisabled, treeState })`
+  Note: the function uses the state _after_ the selection.
+
+## onNodeSelect
+
+- _Arguments_: `onNodeSelect({element, isBranch, isSelected, treeState })`
   Note: the function uses the state _after_ the selection.
 
 ## onExpand
@@ -162,13 +168,14 @@ Follows the same conventions described in https://www.w3.org/TR/wai-aria-practic
 
 The internal state of the component.
 
-| Property           | Type             | Default                       | Description                              |
-| ------------------ | ---------------- | ----------------------------- | ---------------------------------------- |
-| selectedIds        | `Set`            | `new Set(defaultSelectedIds)` | Set of the ids of the selected nodes     |
-| tabbableId         | `number`         | `data[0].children[0]`         | Id of the node with tabindex = 0         |
-| isFocused          | `bool`           | `false`                       | Whether the tree has focus               |
-| expandedIds        | `Set`            | `new Set(defaultExpandedIds)` | Set of the ids of the expanded nodes     |
-| halfSelectedIds    | `Set`            | `new Set()`                   | Set of the ids of the selected nodes     |
-| lastUserSelect     | `number`         | `data[0].children[0]`         | Last selection made directly by the user |
-| lastInteractedWith | `number or null` | `null`                        | Last node interacted with                |
-| disabledIds        | `Set`            | `new Set(defaultDisabledIds)` | Set of the ids of the selected nodes     |
+| Property            | Type             | Default                       | Description                                     |
+| ------------------- | ---------------- | ----------------------------- | ----------------------------------------------- |
+| selectedIds         | `Set`            | `new Set(defaultSelectedIds)` | Set of the ids of the selected nodes            |
+| tabbableId          | `number`         | `data[0].children[0]`         | Id of the node with tabindex = 0                |
+| isFocused           | `bool`           | `false`                       | Whether the tree has focus                      |
+| expandedIds         | `Set`            | `new Set(defaultExpandedIds)` | Set of the ids of the expanded nodes            |
+| halfSelectedIds     | `Set`            | `new Set()`                   | Set of the ids of the selected nodes            |
+| lastUserSelect      | `number`         | `data[0].children[0]`         | Last selection made directly by the user        |
+| lastInteractedWith  | `number or null` | `null`                        | Last node interacted with                       |
+| lastManuallyToggled | `number or null` | `null`                        | Last node that was manually selected/deselected |
+| disabledIds         | `Set`            | `new Set(defaultDisabledIds)` | Set of the ids of the selected nodes            |

--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ Data supports non-sequential ids provided by user.
 ## onNodeSelect
 
 - _Arguments_: `onNodeSelect({element, isBranch, isSelected, treeState })`
-  Note: the function uses the state _after_ the selection.
-
+  Note: the function uses the state right _after_ the selection before propagation.
 ## onExpand
 
 - _Arguments_: `onExpand({element, isExpanded, isSelected, isHalfSelected, isDisabled, treeState})`
@@ -120,7 +119,7 @@ Data supports non-sequential ids provided by user.
 ## onLoadData
 
 - _Arguments_: `onLoadData({element, isExpanded, isSelected, isHalfSelected, isDisabled, treeState})`
-  Note: the function uses the state _after_ inital data is loaded and on expansion .
+  Note: the function uses the state _after_ inital data is loaded and on expansion.
   <br/> <br/>
 
 ## Keyboard Navigation

--- a/src/TreeView/README.md
+++ b/src/TreeView/README.md
@@ -15,6 +15,7 @@ A react component that implements the treeview pattern as described by the [WAI-
 | `data`                   | `array[node]` | `required`    | Tree data                                                                                                                                                                 |
 | `nodeRenderer`           | `func`        | `required`    | Render prop for the node (see below for more details)                                                                                                                     |
 | `onSelect`               | `func`        | `noop`        | Function called when a node changes its selected state                                                                                                                    |
+| `onNodeSelect`           | `func`        | `noop`        | Function called when a node was manually selected/deselected                                                                                                              |
 | `onExpand`               | `func`        | `noop`        | Function called when a node changes its expanded state                                                                                                                    |
 | `className`              | `string`      | `""`          | className to add to the outermost dom element, al `ul` with `role = "tree"`                                                                                               |
 | `multiSelect`            | `bool`        | `false`       | Allows multiple nodes to be selected                                                                                                                                      |
@@ -65,7 +66,7 @@ const data = [
 ];
 ```
 
-The array can also be generated from a nested object using the <code>flattenTree</code> helper (see the examples below). 
+The array can also be generated from a nested object using the <code>flattenTree</code> helper (see the examples below).
 
 Data supports non-sequential ids provided by user.
 
@@ -97,6 +98,11 @@ Data supports non-sequential ids provided by user.
 ### onSelect
 
 - _Arguments_: `onSelect({element, isBranch, isExpanded, isSelected, isHalfSelected, isDisabled, treeState })`
+  Note: the function uses the state _after_ the selection.
+
+## onNodeSelect
+
+- _Arguments_: `onNodeSelect({element, isBranch, isSelected, treeState })`
   Note: the function uses the state _after_ the selection.
 
 ### onExpand

--- a/src/TreeView/README.md
+++ b/src/TreeView/README.md
@@ -103,7 +103,7 @@ Data supports non-sequential ids provided by user.
 ## onNodeSelect
 
 - _Arguments_: `onNodeSelect({element, isBranch, isSelected, treeState })`
-  Note: the function uses the state _after_ the selection.
+  Note: the function uses the state right _after_ the selection before propagation.
 
 ### onExpand
 

--- a/src/TreeView/constants.ts
+++ b/src/TreeView/constants.ts
@@ -1,0 +1,24 @@
+export const baseClassNames = {
+  root: "tree",
+  node: "tree-node",
+  branch: "tree-node__branch",
+  branchWrapper: "tree-branch-wrapper",
+  leafListItem: "tree-leaf-list-item",
+  leaf: "tree-node__leaf",
+  nodeGroup: "tree-node-group",
+} as const;
+
+export const clickActions = {
+  select: "SELECT",
+  focus: "FOCUS",
+  exclusiveSelect: "EXCLUSIVE_SELECT",
+} as const;
+
+export const CLICK_ACTIONS = Object.freeze(Object.values(clickActions));
+
+export const nodeActions = {
+  check: "check",
+  select: "select",
+} as const;
+
+export const NODE_ACTIONS = Object.freeze(Object.values(nodeActions));

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -38,7 +38,6 @@ import {
   getTreeNode,
   validateTreeViewData,
   noop,
-  getAncestors,
 } from "./utils";
 import { Node } from "./node";
 import {
@@ -140,53 +139,21 @@ const useTree = ({
     state,
   ]);
 
-  const prevHalfSelected = usePrevious(halfSelectedIds) || new Set<number>();
   useEffect(() => {
     if (onNodeSelect != null && onNodeSelect !== noop) {
-      const isSelectedIdsChanged =
-        difference(prevSelectedIds, selectedIds).size ||
-        difference(selectedIds, prevSelectedIds).size;
-      const isHalfSelectedIdsChanged =
-        difference(prevHalfSelected, halfSelectedIds).size ||
-        difference(halfSelectedIds, prevHalfSelected).size;
-
       if (lastManuallyToggled != null) {
-        const onNodeSelectProps = {
-          element: getTreeNode(data, lastManuallyToggled),
-          isSelected: selectedIds.has(lastManuallyToggled),
-          isBranch: isBranchNode(data, lastManuallyToggled),
-          treeState: state,
-        };
-        if (
-          propagateSelectUpwards &&
-          getAncestors(data, lastManuallyToggled, disabledIds).length
-        ) {
-          const { some } = propagateSelectChange(
-            data,
-            new Set([lastManuallyToggled]),
-            selectedIds,
-            disabledIds,
-            halfSelectedIds,
-            multiSelect
-          );
-          if (isHalfSelectedIdsChanged) {
-            //when node click triggers propagation and both halfSelectedIds and selectedIds changed
-            onNodeSelect(onNodeSelectProps);
-          } else if (
-            some.size &&
-            !Array.from(some).find((i) => !halfSelectedIds.has(i)) &&
-            isSelectedIdsChanged
-          ) {
-            //when node click doesn't trigger propagation, but selectedIds changed
-            onNodeSelect(onNodeSelectProps);
-          }
-        } else if (isSelectedIdsChanged) {
-          //when node click doesn't trigger propagation
-          onNodeSelect(onNodeSelectProps);
+        if (toggledIds.size) {
+          onNodeSelect({
+            element: getTreeNode(data, lastManuallyToggled),
+            isSelected: selectedIds.has(lastManuallyToggled),
+            isBranch: isBranchNode(data, lastManuallyToggled),
+            treeState: state,
+          });
+          dispatch({ type: treeTypes.clearLastManuallyToggled });
         }
       }
     }
-  }, [lastManuallyToggled, selectedIds, halfSelectedIds]);
+  }, [lastManuallyToggled, selectedIds, toggledIds]);
 
   const prevExpandedIds = usePrevious(expandedIds) || new Set<number>();
   useEffect(() => {

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -38,6 +38,7 @@ import {
   getTreeNode,
   validateTreeViewData,
   noop,
+  getAncestors,
 } from "./utils";
 import { Node } from "./node";
 import {
@@ -139,24 +140,53 @@ const useTree = ({
     state,
   ]);
 
+  const prevHalfSelected = usePrevious(halfSelectedIds) || new Set<number>();
   useEffect(() => {
     if (onNodeSelect != null && onNodeSelect !== noop) {
-      const diffDeselectedIds = difference(prevSelectedIds, selectedIds);
-      const diffSelectedIds = difference(selectedIds, prevSelectedIds);
+      const isSelectedIdsChanged =
+        difference(prevSelectedIds, selectedIds).size ||
+        difference(selectedIds, prevSelectedIds).size;
+      const isHalfSelectedIdsChanged =
+        difference(prevHalfSelected, halfSelectedIds).size ||
+        difference(halfSelectedIds, prevHalfSelected).size;
 
-      if (
-        lastManuallyToggled != null &&
-        (diffSelectedIds.size || diffDeselectedIds.size)
-      ) {
-        onNodeSelect({
+      if (lastManuallyToggled != null) {
+        const onNodeSelectProps = {
           element: getTreeNode(data, lastManuallyToggled),
           isSelected: selectedIds.has(lastManuallyToggled),
           isBranch: isBranchNode(data, lastManuallyToggled),
           treeState: state,
-        });
+        };
+        if (
+          propagateSelectUpwards &&
+          getAncestors(data, lastManuallyToggled, disabledIds).length
+        ) {
+          const { some } = propagateSelectChange(
+            data,
+            new Set([lastManuallyToggled]),
+            selectedIds,
+            disabledIds,
+            halfSelectedIds,
+            multiSelect
+          );
+          if (isHalfSelectedIdsChanged) {
+            //when node click triggers propagation and both halfSelectedIds and selectedIds changed
+            onNodeSelect(onNodeSelectProps);
+          } else if (
+            some.size &&
+            !Array.from(some).find((i) => !halfSelectedIds.has(i)) &&
+            isSelectedIdsChanged
+          ) {
+            //when node click doesn't trigger propagation, but selectedIds changed
+            onNodeSelect(onNodeSelectProps);
+          }
+        } else if (isSelectedIdsChanged) {
+          //when node click doesn't trigger propagation
+          onNodeSelect(onNodeSelectProps);
+        }
       }
     }
-  }, [lastManuallyToggled, selectedIds]);
+  }, [lastManuallyToggled, selectedIds, halfSelectedIds]);
 
   const prevExpandedIds = usePrevious(expandedIds) || new Set<number>();
   useEffect(() => {

--- a/src/TreeView/node.tsx
+++ b/src/TreeView/node.tsx
@@ -145,6 +145,7 @@ export const Node = (props: INodeProps) => {
         multiSelect,
         ids,
         lastInteractedWith: element.id,
+        lastManuallyToggled: element.id,
       });
     } else if (event.ctrlKey || clickAction === clickActions.select) {
       const isSelectedAndHasSelectedDescendants = isBranchSelectedAndHasSelectedDescendants(
@@ -163,6 +164,7 @@ export const Node = (props: INodeProps) => {
         id: element.id,
         multiSelect,
         lastInteractedWith: element.id,
+        lastManuallyToggled: element.id,
       });
       propagateSelect &&
         !disabledIds.has(element.id) &&
@@ -172,6 +174,7 @@ export const Node = (props: INodeProps) => {
           select: togglableSelect ? !selectedIds.has(element.id) : true,
           multiSelect,
           lastInteractedWith: element.id,
+          lastManuallyToggled: element.id,
         });
     } else if (clickAction === clickActions.exclusiveSelect) {
       dispatch({
@@ -179,6 +182,7 @@ export const Node = (props: INodeProps) => {
         id: element.id,
         multiSelect: false,
         lastInteractedWith: element.id,
+        lastManuallyToggled: element.id,
       });
     } else if (clickAction === clickActions.focus) {
       dispatch({

--- a/src/TreeView/node.tsx
+++ b/src/TreeView/node.tsx
@@ -1,0 +1,345 @@
+import React from "react";
+import cx from "classnames";
+import { ITreeViewState, treeTypes, TreeViewAction } from "./reducer";
+import {
+  ClickActions,
+  EventCallback,
+  INode,
+  INodeRef,
+  INodeRefs,
+  INodeRendererProps,
+  NodeAction,
+  NodeId,
+  TreeViewData,
+} from "./types";
+import {
+  composeHandlers,
+  getAccessibleRange,
+  getAriaChecked,
+  getAriaSelected,
+  getDescendants,
+  getTreeNode,
+  isBranchNode,
+  isBranchSelectedAndHasSelectedDescendants,
+  noop,
+  propagatedIds,
+} from "./utils";
+import { baseClassNames, clickActions } from "./constants";
+
+export interface INodeProps {
+  element: INode;
+  dispatch: React.Dispatch<TreeViewAction>;
+  data: TreeViewData;
+  nodeAction: NodeAction;
+  selectedIds: Set<NodeId>;
+  tabbableId: NodeId;
+  isFocused: boolean;
+  expandedIds: Set<NodeId>;
+  disabledIds: Set<NodeId>;
+  halfSelectedIds: Set<NodeId>;
+  lastUserSelect: NodeId;
+  nodeRefs: INodeRefs;
+  leafRefs: INodeRefs;
+  baseClassNames: typeof baseClassNames;
+  nodeRenderer: (props: INodeRendererProps) => React.ReactNode;
+  setsize: number;
+  posinset: number;
+  level: number;
+  propagateCollapse: boolean;
+  propagateSelect: boolean;
+  multiSelect: boolean;
+  togglableSelect: boolean;
+  clickAction?: ClickActions;
+  state: ITreeViewState;
+  propagateSelectUpwards: boolean;
+}
+
+export interface INodeGroupProps
+  extends Omit<INodeProps, "setsize" | "posinset"> {
+  getClasses: (className: string) => string;
+  /** don't send this. The NodeGroup render function, determines it for you */
+  setsize?: undefined;
+  /** don't send this. The NodeGroup render function, determines it for you */
+  posinset?: undefined;
+}
+
+/**
+ * It's convenient to pass props down to the child, but we don't want to pass everything since it would create incorrect values for setsize and posinset
+ */
+const removeIrrelevantGroupProps = (
+  nodeProps: INodeProps
+): Omit<INodeGroupProps, "getClasses"> => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { setsize, posinset, ...rest } = nodeProps;
+  return rest;
+};
+
+export const Node = (props: INodeProps) => {
+  const {
+    element,
+    dispatch,
+    data,
+    selectedIds,
+    tabbableId,
+    isFocused,
+    expandedIds,
+    disabledIds,
+    halfSelectedIds,
+    lastUserSelect,
+    nodeRefs,
+    leafRefs,
+    baseClassNames,
+    nodeRenderer,
+    nodeAction,
+    setsize,
+    posinset,
+    level,
+    propagateCollapse,
+    propagateSelect,
+    multiSelect,
+    togglableSelect,
+    clickAction,
+    state,
+  } = props;
+
+  const handleExpand: EventCallback = (event) => {
+    if (event.ctrlKey || event.altKey || event.shiftKey) return;
+    if (expandedIds.has(element.id) && propagateCollapse) {
+      const ids: NodeId[] = [
+        element.id,
+        ...getDescendants(data, element.id, new Set<NodeId>()),
+      ];
+      dispatch({
+        type: treeTypes.collapseMany,
+        ids,
+        lastInteractedWith: element.id,
+      });
+    } else {
+      dispatch({
+        type: treeTypes.toggle,
+        id: element.id,
+        lastInteractedWith: element.id,
+      });
+    }
+  };
+
+  const handleFocus = (): void =>
+    dispatch({
+      type: treeTypes.focus,
+      id: element.id,
+      lastInteractedWith: element.id,
+    });
+
+  const handleSelect: EventCallback = (event) => {
+    if (event.shiftKey) {
+      let ids = getAccessibleRange({
+        data,
+        expandedIds,
+        from: lastUserSelect,
+        to: element.id,
+      }).filter((id) => !disabledIds.has(id));
+      ids = propagateSelect ? propagatedIds(data, ids, disabledIds) : ids;
+      dispatch({
+        type: treeTypes.exclusiveChangeSelectMany,
+        select: true,
+        multiSelect,
+        ids,
+        lastInteractedWith: element.id,
+      });
+    } else if (event.ctrlKey || clickAction === clickActions.select) {
+      const isSelectedAndHasSelectedDescendants = isBranchSelectedAndHasSelectedDescendants(
+        data,
+        element.id,
+        selectedIds
+      );
+
+      //Select
+      dispatch({
+        type: togglableSelect
+          ? isSelectedAndHasSelectedDescendants
+            ? treeTypes.halfSelect
+            : treeTypes.toggleSelect
+          : treeTypes.select,
+        id: element.id,
+        multiSelect,
+        lastInteractedWith: element.id,
+      });
+      propagateSelect &&
+        !disabledIds.has(element.id) &&
+        dispatch({
+          type: treeTypes.changeSelectMany,
+          ids: propagatedIds(data, [element.id], disabledIds),
+          select: togglableSelect ? !selectedIds.has(element.id) : true,
+          multiSelect,
+          lastInteractedWith: element.id,
+        });
+    } else if (clickAction === clickActions.exclusiveSelect) {
+      dispatch({
+        type: togglableSelect ? treeTypes.toggleSelect : treeTypes.select,
+        id: element.id,
+        multiSelect: false,
+        lastInteractedWith: element.id,
+      });
+    } else if (clickAction === clickActions.focus) {
+      dispatch({
+        type: treeTypes.focus,
+        id: element.id,
+        lastInteractedWith: element.id,
+      });
+    }
+  };
+
+  const getClasses = (className: string) => {
+    return cx(className, {
+      [`${className}--expanded`]: expandedIds.has(element.id),
+      [`${className}--selected`]: selectedIds.has(element.id),
+      [`${className}--focused`]: tabbableId === element.id && isFocused,
+    });
+  };
+  const ariaActionProp =
+    nodeAction === "select"
+      ? {
+          "aria-selected": getAriaSelected({
+            isSelected: selectedIds.has(element.id),
+            isDisabled: disabledIds.has(element.id),
+            multiSelect,
+          }),
+        }
+      : {
+          "aria-checked": getAriaChecked({
+            isSelected: selectedIds.has(element.id),
+            isDisabled: disabledIds.has(element.id),
+            isHalfSelected: halfSelectedIds.has(element.id),
+            multiSelect,
+          }),
+        };
+  const getLeafProps = (args: { onClick?: EventCallback } = {}) => {
+    const { onClick } = args;
+    return {
+      role: "treeitem",
+      tabIndex: tabbableId === element.id ? 0 : -1,
+      onClick:
+        onClick == null
+          ? composeHandlers(handleSelect, handleFocus)
+          : composeHandlers(onClick, handleFocus),
+      ref: (x: INodeRef) => {
+        if (nodeRefs?.current != null && leafRefs?.current != null) {
+          nodeRefs.current[element.id] = x;
+          leafRefs.current[element.id] = x;
+        }
+      },
+      className: cx(getClasses(baseClassNames.node), baseClassNames.leaf),
+      "aria-setsize": setsize,
+      "aria-posinset": posinset,
+      "aria-level": level,
+      disabled: disabledIds.has(element.id),
+      "aria-disabled": disabledIds.has(element.id),
+      ...ariaActionProp,
+    };
+  };
+
+  const getBranchLeafProps = (args: { onClick?: EventCallback } = {}) => {
+    const { onClick } = args;
+    return {
+      onClick:
+        onClick == null
+          ? composeHandlers(handleSelect, handleExpand, handleFocus)
+          : composeHandlers(onClick, handleFocus),
+      className: cx(getClasses(baseClassNames.node), baseClassNames.branch),
+      ref: (x: INodeRef) => {
+        if (leafRefs?.current != null) {
+          leafRefs.current[element.id] = x;
+        }
+      },
+    };
+  };
+
+  return isBranchNode(data, element.id) || element.isBranch ? (
+    <li
+      role="treeitem"
+      aria-expanded={expandedIds.has(element.id)}
+      aria-setsize={setsize}
+      aria-posinset={posinset}
+      aria-level={level}
+      aria-disabled={disabledIds.has(element.id)}
+      tabIndex={tabbableId === element.id ? 0 : -1}
+      ref={(x) => {
+        if (nodeRefs?.current != null && x != null) {
+          nodeRefs.current[element.id] = x;
+        }
+      }}
+      className={baseClassNames.branchWrapper}
+      {...ariaActionProp}
+    >
+      <>
+        {nodeRenderer({
+          element,
+          isBranch: true,
+          isSelected: selectedIds.has(element.id),
+          isHalfSelected: halfSelectedIds.has(element.id),
+          isExpanded: expandedIds.has(element.id),
+          isDisabled: disabledIds.has(element.id),
+          dispatch,
+          getNodeProps: getBranchLeafProps,
+          setsize,
+          posinset,
+          level,
+          handleSelect,
+          handleExpand,
+          treeState: state,
+        })}
+        <NodeGroup
+          getClasses={getClasses}
+          {...removeIrrelevantGroupProps(props)}
+        />
+      </>
+    </li>
+  ) : (
+    <li role="none" className={getClasses(baseClassNames.leafListItem)}>
+      {nodeRenderer({
+        element,
+        isBranch: false,
+        isSelected: selectedIds.has(element.id),
+        isHalfSelected: false,
+        isExpanded: false,
+        isDisabled: disabledIds.has(element.id),
+        dispatch,
+        getNodeProps: getLeafProps,
+        setsize,
+        posinset,
+        level,
+        handleSelect,
+        handleExpand: noop,
+        treeState: state,
+      })}
+    </li>
+  );
+};
+
+export const NodeGroup = ({
+  data,
+  element,
+  expandedIds,
+  getClasses,
+  baseClassNames,
+  level,
+  ...rest
+}: INodeGroupProps) => (
+  <ul role="group" className={getClasses(baseClassNames.nodeGroup)}>
+    {expandedIds.has(element.id) &&
+      element.children.length > 0 &&
+      element.children.map((x, index) => (
+        <Node
+          data={data}
+          expandedIds={expandedIds}
+          baseClassNames={baseClassNames}
+          key={`${x}-${typeof x}`}
+          element={getTreeNode(data, x)}
+          setsize={element.children.length}
+          posinset={index + 1}
+          level={level + 1}
+          {...rest}
+        />
+      ))}
+  </ul>
+);

--- a/src/TreeView/reducer.ts
+++ b/src/TreeView/reducer.ts
@@ -37,6 +37,7 @@ export type TreeViewAction =
       keepFocus?: boolean;
       NotUserAction?: boolean;
       lastInteractedWith?: NodeId | null;
+      lastManuallyToggled?: NodeId | null;
     }
   | {
       type: "DESELECT";
@@ -46,6 +47,7 @@ export type TreeViewAction =
       keepFocus?: boolean;
       NotUserAction?: boolean;
       lastInteractedWith?: NodeId | null;
+      lastManuallyToggled?: NodeId | null;
     }
   | { type: "TOGGLE"; id: NodeId; lastInteractedWith?: NodeId | null }
   | {
@@ -54,6 +56,7 @@ export type TreeViewAction =
       multiSelect?: boolean;
       NotUserAction?: boolean;
       lastInteractedWith?: NodeId | null;
+      lastManuallyToggled?: NodeId | null;
     }
   | {
       type: "SELECT_MANY";
@@ -61,6 +64,7 @@ export type TreeViewAction =
       select?: boolean;
       multiSelect?: boolean;
       lastInteractedWith?: NodeId | null;
+      lastManuallyToggled?: NodeId | null;
     }
   | { type: "EXCLUSIVE_SELECT_MANY" }
   | {
@@ -69,6 +73,7 @@ export type TreeViewAction =
       select?: boolean;
       multiSelect?: boolean;
       lastInteractedWith?: NodeId | null;
+      lastManuallyToggled?: NodeId | null;
     }
   | { type: "FOCUS"; id: NodeId; lastInteractedWith?: NodeId | null }
   | { type: "BLUR" }
@@ -92,6 +97,8 @@ export interface ITreeViewState {
   lastUserSelect: NodeId;
   /** Last node interacted with */
   lastInteractedWith?: NodeId | null;
+  /** Last node manually selected/deselected */
+  lastManuallyToggled?: NodeId | null;
   lastAction?: TreeViewAction["type"];
 }
 
@@ -197,6 +204,7 @@ export const treeReducer = (
         lastUserSelect: action.NotUserAction ? state.lastUserSelect : action.id,
         lastAction: action.type,
         lastInteractedWith: action.lastInteractedWith,
+        lastManuallyToggled: action.lastManuallyToggled,
       };
     }
     case treeTypes.deselect: {
@@ -220,6 +228,7 @@ export const treeReducer = (
         lastUserSelect: action.NotUserAction ? state.lastUserSelect : action.id,
         lastAction: action.type,
         lastInteractedWith: action.lastInteractedWith,
+        lastManuallyToggled: action.lastManuallyToggled,
       };
     }
     case treeTypes.toggleSelect: {
@@ -246,6 +255,7 @@ export const treeReducer = (
         lastUserSelect: action.NotUserAction ? state.lastUserSelect : action.id,
         lastAction: action.type,
         lastInteractedWith: action.lastInteractedWith,
+        lastManuallyToggled: action.lastManuallyToggled,
       };
     }
     case treeTypes.changeSelectMany: {
@@ -264,6 +274,7 @@ export const treeReducer = (
           halfSelectedIds,
           lastAction: action.type,
           lastInteractedWith: action.lastInteractedWith,
+          lastManuallyToggled: action.lastManuallyToggled,
         };
       }
       return state;
@@ -284,6 +295,7 @@ export const treeReducer = (
           halfSelectedIds,
           lastAction: action.type,
           lastInteractedWith: action.lastInteractedWith,
+          lastManuallyToggled: action.lastManuallyToggled,
         };
       }
       return state;

--- a/src/TreeView/reducer.ts
+++ b/src/TreeView/reducer.ts
@@ -17,6 +17,7 @@ export const treeTypes = {
   blur: "BLUR",
   disable: "DISABLE",
   enable: "ENABLE",
+  clearLastManuallyToggled: "CLEAR_MANUALLY_TOGGLED",
 } as const;
 
 export type TreeViewAction =
@@ -78,7 +79,8 @@ export type TreeViewAction =
   | { type: "FOCUS"; id: NodeId; lastInteractedWith?: NodeId | null }
   | { type: "BLUR" }
   | { type: "DISABLE"; id: NodeId }
-  | { type: "ENABLE"; id: NodeId };
+  | { type: "ENABLE"; id: NodeId }
+  | { type: "CLEAR_MANUALLY_TOGGLED" };
 
 export interface ITreeViewState {
   /** Set of the ids of the expanded nodes */
@@ -327,6 +329,12 @@ export const treeReducer = (
       return {
         ...state,
         disabledIds,
+      };
+    }
+    case treeTypes.clearLastManuallyToggled: {
+      return {
+        ...state,
+        lastManuallyToggled: null,
       };
     }
     default:

--- a/src/TreeView/types.ts
+++ b/src/TreeView/types.ts
@@ -1,17 +1,13 @@
+import { clickActions, nodeActions } from "./constants";
+import { ITreeViewState, TreeViewAction } from "./reducer";
+
+export type ValueOf<T> = T[keyof T];
+export type ClickActions = ValueOf<typeof clickActions>;
+
+export type NodeAction = ValueOf<typeof nodeActions>;
+
 export type NodeId = number | string;
 
-export interface INode {
-  /** A non-negative integer that uniquely identifies the node */
-  id: NodeId;
-  /** Used to match on key press */
-  name: string;
-  /** An array with the ids of the children nodes */
-  children: NodeId[];
-  /** The parent of the node; null for the root node */
-  parent: NodeId | null;
-  /** Used to indicated whether a node is branch to be able load async data onExpand*/
-  isBranch?: boolean;
-}
 export type INodeRef = HTMLLIElement | HTMLDivElement;
 export type INodeRefs = null | React.RefObject<{
   [key: NodeId]: INodeRef;
@@ -21,4 +17,77 @@ export type TreeViewData = INode[];
 
 export type EventCallback = <T, E>(
   event: React.MouseEvent<T, E> | React.KeyboardEvent<T>
-) => void;
+  ) => void;
+  
+  export interface INode {
+    /** A non-negative integer that uniquely identifies the node */
+    id: NodeId;
+    /** Used to match on key press */
+    name: string;
+    /** An array with the ids of the children nodes */
+    children: NodeId[];
+    /** The parent of the node; null for the root node */
+    parent: NodeId | null;
+    /** Used to indicated whether a node is branch to be able load async data onExpand*/
+    isBranch?: boolean;
+  }
+
+  export interface INodeRendererProps {
+    /** The object that represents the rendered node */
+    element: INode;
+    /** A function which gives back the props to pass to the node */
+    getNodeProps: (args?: {
+      onClick?: EventCallback;
+    }) => IBranchProps | LeafProps;
+    /** Whether the rendered node is a branch node */
+    isBranch: boolean;
+    /** Whether the rendered node is selected */
+    isSelected: boolean;
+    /** If the node is a branch node, whether it is half-selected, else undefined */
+    isHalfSelected: boolean;
+    /** If the node is a branch node, whether it is expanded, else undefined */
+    isExpanded: boolean;
+    /** Whether the rendered node is disabled */
+    isDisabled: boolean;
+    /** A positive integer that corresponds to the aria-level attribute */
+    level: number;
+    /** A positive integer that corresponds to the aria-setsize attribute */
+    setsize: number;
+    /** A positive integer that corresponds to the aria-posinset attribute */
+    posinset: number;
+    /** Function to assign to the onClick event handler of the element(s) that will toggle the selected state */
+    handleSelect: EventCallback;
+    /** Function to assign to the onClick event handler of the element(s) that will toggle the expanded state */
+    handleExpand: EventCallback;
+    /** Function to dispatch actions */
+    dispatch: React.Dispatch<TreeViewAction>;
+    /** state of the treeview */
+    treeState: ITreeViewState;
+  }
+
+  type ActionableNode =
+  | {
+      "aria-selected": boolean | undefined;
+    }
+  | {
+      "aria-checked": boolean | undefined | "mixed";
+    };
+
+  export type LeafProps = ActionableNode & {
+    role: string;
+    tabIndex: number;
+    onClick: EventCallback;
+    ref: <T extends INodeRef>(x: T | null) => void;
+    className: string;
+    "aria-setsize": number;
+    "aria-posinset": number;
+    "aria-level": number;
+    "aria-selected": boolean;
+    disabled: boolean;
+    "aria-disabled": boolean;
+  };
+  
+  export interface IBranchProps {
+    onClick: EventCallback;
+    className: string;
+  }

--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -1,6 +1,9 @@
 import { useEffect, useRef } from "react";
 import { EventCallback, INode, INodeRef, NodeId, TreeViewData } from "./types";
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export const noop = () => {};
+
 export const composeHandlers = (
   ...handlers: EventCallback[]
 ): EventCallback => (event): void => {

--- a/src/__tests__/TreeViewOnNodeSelect.test.tsx
+++ b/src/__tests__/TreeViewOnNodeSelect.test.tsx
@@ -101,20 +101,37 @@ test("onNodeSelect should be called when node manually seelcted/deselected", () 
   const { queryAllByRole } = render(<TreeViewOnNodeSelect />);
   const nodes = queryAllByRole("treeitem");
 
-  const expected = {
+  const expectedSelected = {
     element: { children: [], id: 5, name: "Oranges", parent: 1 },
     isBranch: false,
     isSelected: true,
     treeState: {
       disabledIds: new Set(),
       expandedIds: new Set([1, 7, 11, 16]),
-      halfSelectedIds: new Set([1]), // this not present currently
+      halfSelectedIds: new Set(),
       isFocused: true,
-      lastAction: "HALF_SELECT",
+      lastAction: "SELECT_MANY",
       lastInteractedWith: 5,
       lastManuallyToggled: 5,
       lastUserSelect: 5,
       selectedIds: new Set([5]),
+      tabbableId: 5,
+    },
+  };
+  const expectedDeselected = {
+    element: { children: [], id: 5, name: "Oranges", parent: 1 },
+    isBranch: false,
+    isSelected: false,
+    treeState: {
+      disabledIds: new Set(),
+      expandedIds: new Set([1, 7, 11, 16]),
+      halfSelectedIds: new Set([1]),
+      isFocused: true,
+      lastAction: "SELECT_MANY",
+      lastInteractedWith: 5,
+      lastManuallyToggled: 5,
+      lastUserSelect: 5,
+      selectedIds: new Set(),
       tabbableId: 5,
     },
   };
@@ -126,8 +143,13 @@ test("onNodeSelect should be called when node manually seelcted/deselected", () 
 
   fireEvent.click(nodes[4].getElementsByClassName("checkbox-icon")[0]);
 
-  expect(console.log).toBeCalledWith(expected);
+  expect(console.log).toBeCalledWith(expectedSelected);
   expect(nodes[4]).toHaveAttribute("aria-checked", "true");
+
+  fireEvent.click(nodes[4].getElementsByClassName("checkbox-icon")[0]);
+
+  expect(console.log).toBeCalledWith(expectedDeselected);
+  expect(nodes[4]).toHaveAttribute("aria-checked", "false");
 });
 
 test("onNodeSelect should be called only for interacted node", () => {
@@ -182,9 +204,9 @@ describe("onNodeSelect should be called when node selected/deselected via keyboa
       treeState: {
         disabledIds: new Set(),
         expandedIds: new Set([1, 7, 11, 16]),
-        halfSelectedIds: new Set([1]), // this not present currently
+        halfSelectedIds: new Set(),
         isFocused: true,
-        lastAction: "HALF_SELECT",
+        lastAction: "SELECT_MANY",
         lastInteractedWith: 2,
         lastManuallyToggled: 2,
         lastUserSelect: 2,
@@ -215,9 +237,9 @@ describe("onNodeSelect should be called when node selected/deselected via keyboa
       treeState: {
         disabledIds: new Set(),
         expandedIds: new Set([1, 7, 11, 16]),
-        halfSelectedIds: new Set([1]), // this not present currently
+        halfSelectedIds: new Set(),
         isFocused: true,
-        lastAction: "HALF_SELECT",
+        lastAction: "SELECT_MANY",
         lastInteractedWith: 2,
         lastManuallyToggled: 2,
         lastUserSelect: 2,
@@ -284,9 +306,9 @@ describe("onNodeSelect should be called when node selected/deselected via keyboa
       treeState: {
         disabledIds: new Set(),
         expandedIds: new Set([1, 7, 11, 16]),
-        halfSelectedIds: new Set([1]), // this not present currently
+        halfSelectedIds: new Set(),
         isFocused: true,
-        lastAction: "HALF_SELECT",
+        lastAction: "FOCUS",
         lastInteractedWith: 2,
         lastManuallyToggled: 2,
         lastUserSelect: 1,

--- a/src/__tests__/TreeViewOnNodeSelect.test.tsx
+++ b/src/__tests__/TreeViewOnNodeSelect.test.tsx
@@ -1,0 +1,311 @@
+import "@testing-library/jest-dom/extend-expect";
+import React from "react";
+import TreeView from "../TreeView";
+import { fireEvent, render } from "@testing-library/react";
+import { flattenTree } from "../TreeView/utils";
+import { NodeId } from "../TreeView/types";
+
+const folder = {
+  name: "",
+  children: [
+    {
+      name: "Fruits",
+      children: [
+        { name: "Avocados" },
+        { name: "Bananas" },
+        { name: "Berries" },
+        { name: "Oranges" },
+        { name: "Pears" },
+      ],
+    },
+    {
+      name: "Drinks",
+      children: [
+        { name: "Apple Juice" },
+        { name: "Chocolate" },
+        { name: "Coffee" },
+        {
+          name: "Tea",
+          children: [
+            { name: "Black Tea" },
+            { name: "Green Tea" },
+            { name: "Red Tea" },
+            { name: "Matcha" },
+          ],
+        },
+      ],
+    },
+    {
+      name: "Vegetables",
+      children: [
+        { name: "Beets" },
+        { name: "Carrots" },
+        { name: "Celery" },
+        { name: "Lettuce" },
+        { name: "Onions" },
+      ],
+    },
+  ],
+};
+
+const data = flattenTree(folder);
+
+interface TreeViewOnNodeSelectProps {
+  selectedIds?: NodeId[];
+}
+
+function TreeViewOnNodeSelect(props: TreeViewOnNodeSelectProps) {
+  const { selectedIds } = props;
+  return (
+    <div>
+      <TreeView
+        data={data}
+        aria-label="onNodeSelect"
+        selectedIds={selectedIds}
+        onNodeSelect={(props) => console.log(props)}
+        multiSelect
+        defaultExpandedIds={[1, 7, 11, 16]}
+        propagateSelect
+        propagateSelectUpwards
+        togglableSelect
+        nodeAction="check"
+        nodeRenderer={({
+          element,
+          getNodeProps,
+          handleSelect,
+          handleExpand,
+        }) => {
+          return (
+            <div {...getNodeProps({ onClick: handleExpand })}>
+              <div
+                className="checkbox-icon"
+                onClick={(e) => {
+                  handleSelect(e);
+                  e.stopPropagation();
+                }}
+              />
+              <span className="element">
+                {element.name}-{element.id}
+              </span>
+            </div>
+          );
+        }}
+      />
+    </div>
+  );
+}
+
+jest.spyOn(global.console, "log");
+
+test("onNodeSelect should be called when node manually seelcted/deselected", () => {
+  const { queryAllByRole } = render(<TreeViewOnNodeSelect />);
+  const nodes = queryAllByRole("treeitem");
+
+  const expected = {
+    element: { children: [], id: 5, name: "Oranges", parent: 1 },
+    isBranch: false,
+    isSelected: true,
+    treeState: {
+      disabledIds: new Set(),
+      expandedIds: new Set([1, 7, 11, 16]),
+      halfSelectedIds: new Set([1]), // this not present currently
+      isFocused: true,
+      lastAction: "HALF_SELECT",
+      lastInteractedWith: 5,
+      lastManuallyToggled: 5,
+      lastUserSelect: 5,
+      selectedIds: new Set([5]),
+      tabbableId: 5,
+    },
+  };
+
+  if (document.activeElement == null)
+    throw new Error(
+      `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
+    );
+
+  fireEvent.click(nodes[4].getElementsByClassName("checkbox-icon")[0]);
+
+  expect(console.log).toBeCalledWith(expected);
+  expect(nodes[4]).toHaveAttribute("aria-checked", "true");
+});
+
+test("onNodeSelect should be called only for interacted node", () => {
+  const { queryAllByRole } = render(<TreeViewOnNodeSelect />);
+  const nodes = queryAllByRole("treeitem");
+
+  const expected = {
+    element: { id: 1, name: "Fruits", children: [2, 3, 4, 5, 6], parent: 0 },
+    isSelected: true,
+    isBranch: true,
+    treeState: {
+      disabledIds: new Set(),
+      expandedIds: new Set([1, 7, 11, 16]),
+      halfSelectedIds: new Set(),
+      isFocused: true,
+      lastAction: "SELECT_MANY",
+      lastInteractedWith: 1,
+      lastManuallyToggled: 1,
+      lastUserSelect: 1,
+      selectedIds: new Set([1, 2, 3, 4, 5, 6]),
+      tabbableId: 1,
+    },
+  };
+
+  if (document.activeElement == null)
+    throw new Error(
+      `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
+    );
+
+  fireEvent.click(nodes[0].getElementsByClassName("checkbox-icon")[0]);
+
+  expect(console.log).toBeCalledWith(expected);
+  expect(nodes[0]).toHaveAttribute("aria-checked", "true");
+  expect(nodes[1]).toHaveAttribute("aria-checked", "true");
+  expect(nodes[2]).toHaveAttribute("aria-checked", "true");
+  expect(nodes[3]).toHaveAttribute("aria-checked", "true");
+  expect(nodes[4]).toHaveAttribute("aria-checked", "true");
+  expect(nodes[5]).toHaveAttribute("aria-checked", "true");
+});
+
+test("onNodeSelect should not be called when controlled selection", () => {
+  render(<TreeViewOnNodeSelect selectedIds={[19]} />);
+  expect(console.log).not.toBeCalled();
+});
+
+describe("onNodeSelect should be called when node selected/deselected via keyboard", () => {
+  test("Enter", () => {
+    const expected = {
+      element: { children: [], id: 2, name: "Avocados", parent: 1 },
+      isBranch: false,
+      isSelected: true,
+      treeState: {
+        disabledIds: new Set(),
+        expandedIds: new Set([1, 7, 11, 16]),
+        halfSelectedIds: new Set([1]), // this not present currently
+        isFocused: true,
+        lastAction: "HALF_SELECT",
+        lastInteractedWith: 2,
+        lastManuallyToggled: 2,
+        lastUserSelect: 2,
+        selectedIds: new Set([2]),
+        tabbableId: 2,
+      },
+    };
+
+    const { queryAllByRole } = render(<TreeViewOnNodeSelect />);
+    const nodes = queryAllByRole("treeitem");
+
+    if (document.activeElement == null)
+      throw new Error(
+        `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
+      );
+    nodes[0].focus(); //Fruits
+    fireEvent.keyDown(nodes[0], { key: "ArrowDown" }); //Avocados
+    fireEvent.keyDown(document.activeElement, { key: "Enter" });
+
+    expect(console.log).toBeCalledWith(expected);
+    expect(nodes[1]).toHaveAttribute("aria-checked", "true");
+  });
+  test("Space", () => {
+    const expected = {
+      element: { children: [], id: 2, name: "Avocados", parent: 1 },
+      isBranch: false,
+      isSelected: true,
+      treeState: {
+        disabledIds: new Set(),
+        expandedIds: new Set([1, 7, 11, 16]),
+        halfSelectedIds: new Set([1]), // this not present currently
+        isFocused: true,
+        lastAction: "HALF_SELECT",
+        lastInteractedWith: 2,
+        lastManuallyToggled: 2,
+        lastUserSelect: 2,
+        selectedIds: new Set([2]),
+        tabbableId: 2,
+      },
+    };
+
+    const { queryAllByRole } = render(<TreeViewOnNodeSelect />);
+    const nodes = queryAllByRole("treeitem");
+
+    if (document.activeElement == null)
+      throw new Error(
+        `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
+      );
+    nodes[0].focus(); //Fruits
+    fireEvent.keyDown(nodes[0], { key: "ArrowDown" }); //Avocados
+    fireEvent.keyDown(document.activeElement, { key: " " });
+
+    expect(console.log).toBeCalledWith(expected);
+    expect(nodes[1]).toHaveAttribute("aria-checked", "true");
+  });
+  test("Shift+ArrowUp", () => {
+    const expected = {
+      element: { id: 1, name: "Fruits", children: [2, 3, 4, 5, 6], parent: 0 },
+      isSelected: true,
+      isBranch: true,
+      treeState: {
+        disabledIds: new Set(),
+        expandedIds: new Set([1, 7, 11, 16]),
+        halfSelectedIds: new Set(),
+        isFocused: true,
+        lastAction: "FOCUS",
+        lastInteractedWith: 1,
+        lastManuallyToggled: 1,
+        lastUserSelect: 1,
+        selectedIds: new Set([1, 2, 3, 4, 5, 6]),
+        tabbableId: 1,
+      },
+    };
+
+    const { queryAllByRole } = render(<TreeViewOnNodeSelect />);
+    const nodes = queryAllByRole("treeitem");
+
+    if (document.activeElement == null)
+      throw new Error(
+        `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
+      );
+    nodes[0].focus(); //Fruits
+    fireEvent.keyDown(nodes[0], { key: "ArrowDown" }); //Avocados
+    fireEvent.keyDown(document.activeElement, {
+      key: "ArrowUp",
+      shiftKey: true,
+    });
+
+    expect(console.log).toBeCalledWith(expected);
+    expect(nodes[0]).toHaveAttribute("aria-checked", "true");
+  });
+  test("Shift+ArrowDown", () => {
+    const expected = {
+      element: { children: [], id: 2, name: "Avocados", parent: 1 },
+      isBranch: false,
+      isSelected: true,
+      treeState: {
+        disabledIds: new Set(),
+        expandedIds: new Set([1, 7, 11, 16]),
+        halfSelectedIds: new Set([1]), // this not present currently
+        isFocused: true,
+        lastAction: "HALF_SELECT",
+        lastInteractedWith: 2,
+        lastManuallyToggled: 2,
+        lastUserSelect: 1,
+        selectedIds: new Set([2]),
+        tabbableId: 2,
+      },
+    };
+
+    const { queryAllByRole } = render(<TreeViewOnNodeSelect />);
+    const nodes = queryAllByRole("treeitem");
+
+    if (document.activeElement == null)
+      throw new Error(
+        `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
+      );
+    nodes[0].focus(); //Fruits
+    fireEvent.keyDown(nodes[0], { key: "ArrowDown", shiftKey: true }); //Avocados
+
+    expect(console.log).toBeCalledWith(expected);
+    expect(nodes[1]).toHaveAttribute("aria-checked", "true");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,20 @@
 import TreeView, {
-  ClickActions,
-  CLICK_ACTIONS,
-  IBranchProps,
-  LeafProps,
-  INodeRendererProps,
   ITreeViewOnExpandProps,
   ITreeViewOnSelectProps,
   ITreeViewProps,
   ITreeViewOnLoadDataProps,
 } from "./TreeView";
+import { CLICK_ACTIONS } from "./TreeView/constants";
 import { ITreeViewState, TreeViewAction } from "./TreeView/reducer";
-import { INode, TreeViewData, EventCallback } from "./TreeView/types";
+import {
+  INode,
+  TreeViewData,
+  EventCallback,
+  ClickActions,
+  INodeRendererProps,
+  IBranchProps,
+  LeafProps,
+} from "./TreeView/types";
 import { flattenTree } from "./TreeView/utils";
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import TreeView, {
   ITreeViewOnExpandProps,
   ITreeViewOnSelectProps,
+  ITreeViewOnNodeSelectProps,
   ITreeViewProps,
   ITreeViewOnLoadDataProps,
 } from "./TreeView";
@@ -23,6 +24,7 @@ export {
   INode,
   TreeViewData,
   ITreeViewOnSelectProps,
+  ITreeViewOnNodeSelectProps,
   CLICK_ACTIONS,
   ITreeViewOnExpandProps,
   ITreeViewOnLoadDataProps,

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -104,7 +104,7 @@ the handleSelect and handleExpand for just a part of the component, as demonstra
 ## onNodeSelect
 
 - _Arguments_: `onNodeSelect({element, isBranch, isSelected, treeState })`
-  Note: the function uses the state _after_ the selection.
+  Note: the function uses the state right _after_ the selection before propagation.
 
 ## onExpand
 

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -9,6 +9,7 @@ title: API Reference
 | `data`                   | `array[node]` | `required`    | Tree data                                                                                                                                                                 |
 | `nodeRenderer`           | `func`        | `required`    | Render prop for the node (see below for more details)                                                                                                                     |
 | `onSelect`               | `func`        | `noop`        | Function called when a node changes its selected state                                                                                                                    |
+| `onNodeSelect`           | `func`        | `noop`        | Function called when a node was manually selected/deselected                                                                                                              |
 | `onExpand`               | `func`        | `noop`        | Function called when a node changes its expanded state                                                                                                                    |
 | `className`              | `string`      | `""`          | className to add to the outermost dom element, al `ul` with `role = "tree"`                                                                                               |
 | `multiSelect`            | `bool`        | `false`       | Allows multiple nodes to be selected                                                                                                                                      |
@@ -60,7 +61,7 @@ const data = [
 ];
 ```
 
-The array can also be generated from a nested object using the `flattenTree` helper (see the examples below). 
+The array can also be generated from a nested object using the `flattenTree` helper (see the examples below).
 
 Data supports non-sequential ids provided by user.
 
@@ -98,6 +99,11 @@ the handleSelect and handleExpand for just a part of the component, as demonstra
 ## onSelect
 
 - _Arguments_: `onSelect({element, isBranch, isExpanded, isSelected, isHalfSelected, isDisabled, treeState })`
+  Note: the function uses the state _after_ the selection.
+
+## onNodeSelect
+
+- _Arguments_: `onNodeSelect({element, isBranch, isSelected, treeState })`
   Note: the function uses the state _after_ the selection.
 
 ## onExpand
@@ -156,13 +162,14 @@ Follows the same conventions described in https://www.w3.org/TR/wai-aria-practic
 
 The internal state of the component.
 
-| Property           | Type             | Default                       | Description                              |
-| ------------------ | ---------------- | ----------------------------- | ---------------------------------------- |
-| selectedIds        | `Set`            | `new Set(defaultSelectedIds)` | Set of the ids of the selected nodes     |
-| tabbableId         | `number`         | `data[0].children[0]`         | Id of the node with tabindex = 0         |
-| isFocused          | `bool`           | `false`                       | Whether the tree has focus               |
-| expandedIds        | `Set`            | `new Set(defaultExpandedIds)` | Set of the ids of the expanded nodes     |
-| halfSelectedIds    | `Set`            | `new Set()`                   | Set of the ids of the selected nodes     |
-| lastUserSelect     | `number`         | `data[0].children[0]`         | Last selection made directly by the user |
-| lastInteractedWith | `number or null` | `null`                        | Last node interacted with                |
-| disabledIds        | `Set`            | `new Set(defaultDisabledIds)` | Set of the ids of the selected nodes     |
+| Property            | Type             | Default                       | Description                                     |
+| ------------------- | ---------------- | ----------------------------- | ----------------------------------------------- |
+| selectedIds         | `Set`            | `new Set(defaultSelectedIds)` | Set of the ids of the selected nodes            |
+| tabbableId          | `number`         | `data[0].children[0]`         | Id of the node with tabindex = 0                |
+| isFocused           | `bool`           | `false`                       | Whether the tree has focus                      |
+| expandedIds         | `Set`            | `new Set(defaultExpandedIds)` | Set of the ids of the expanded nodes            |
+| halfSelectedIds     | `Set`            | `new Set()`                   | Set of the ids of the selected nodes            |
+| lastUserSelect      | `number`         | `data[0].children[0]`         | Last selection made directly by the user        |
+| lastInteractedWith  | `number or null` | `null`                        | Last node interacted with                       |
+| lastManuallyToggled | `number or null` | `null`                        | Last node that was manually selected/deselected |
+| disabledIds         | `Set`            | `new Set(defaultDisabledIds)` | Set of the ids of the selected nodes            |

--- a/website/docs/examples/MultiSelectCheckboxControlled/index.js
+++ b/website/docs/examples/MultiSelectCheckboxControlled/index.js
@@ -95,6 +95,8 @@ function MultiSelectCheckboxControlled() {
           propagateSelect
           propagateSelectUpwards
           togglableSelect
+          onSelect={(props) => console.log('onSelect callback: ', props)}
+          onNodeSelect={(props) => console.log('onNodeSelect callback: ', props)}
           nodeRenderer={({
             element,
             isBranch,


### PR DESCRIPTION
Added `onNodeSelect` callback that is called rigth after node interaction (with mouse or keyboard). Added tests. Node related logic moved in separate file for readability.

Ref: UIEN-4057