### PR TITLE
Fix issue both parent and only child should be selected when propagation and singleSelect

### DIFF
--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -38,6 +38,7 @@ import {
   validateTreeViewData,
   noop,
   isBranchNotSelectedAndHasAllSelectedDescendants,
+  isBranchSelectedAndHasAllSelectedDescendants,
 } from "./utils";
 import { Node } from "./node";
 import {
@@ -297,10 +298,7 @@ const useTree = ({
   //Update parent if a child changes
   useEffect(() => {
     if (propagateSelectUpwards) {
-      const idsToUpdate = new Set<NodeId>([
-        ...toggledIds,
-        ...controlledIds,
-      ]);
+      const idsToUpdate = new Set<NodeId>([...toggledIds, ...controlledIds]);
       if (
         lastInteractedWith &&
         lastAction !== treeTypes.focus &&
@@ -848,9 +846,16 @@ const handleKeyDown = ({
         selectedIds
       );
 
+      const isSelectedAndHasAllSelectedDescendants = isBranchSelectedAndHasAllSelectedDescendants(
+        data,
+        element.id,
+        selectedIds
+      );
+
       dispatch({
         type: togglableSelect
-          ? isSelectedAndHasSelectedDescendants
+          ? isSelectedAndHasSelectedDescendants &&
+            !isSelectedAndHasAllSelectedDescendants
             ? treeTypes.halfSelect
             : treeTypes.toggleSelect
           : treeTypes.select,

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -37,6 +37,7 @@ import {
   getTreeNode,
   validateTreeViewData,
   noop,
+  isBranchNotSelectedAndHasAllSelectedDescendants,
 } from "./utils";
 import { Node } from "./node";
 import {
@@ -335,7 +336,13 @@ const useTree = ({
           dispatch({
             type: treeTypes.select,
             id,
-            multiSelect,
+            multiSelect: multiSelect
+              ? multiSelect
+              : isBranchNotSelectedAndHasAllSelectedDescendants(
+                  data,
+                  id,
+                  selectedIds
+                ),
             keepFocus: true,
             NotUserAction: true,
             lastInteractedWith,

--- a/src/TreeView/node.tsx
+++ b/src/TreeView/node.tsx
@@ -19,6 +19,7 @@ import {
   getDescendants,
   getTreeNode,
   isBranchNode,
+  isBranchSelectedAndHasAllSelectedDescendants,
   isBranchSelectedAndHasSelectedDescendants,
   noop,
   propagatedIds,
@@ -153,10 +154,17 @@ export const Node = (props: INodeProps) => {
         selectedIds
       );
 
+      const isSelectedAndHasAllSelectedDescendants = isBranchSelectedAndHasAllSelectedDescendants(
+        data,
+        element.id,
+        selectedIds
+      );
+
       //Select
       dispatch({
         type: togglableSelect
-          ? isSelectedAndHasSelectedDescendants
+          ? isSelectedAndHasSelectedDescendants &&
+            !isSelectedAndHasAllSelectedDescendants
             ? treeTypes.halfSelect
             : treeTypes.toggleSelect
           : treeTypes.select,

--- a/src/TreeView/reducer.ts
+++ b/src/TreeView/reducer.ts
@@ -191,7 +191,8 @@ export const treeReducer = (
       };
     }
     case treeTypes.select: {
-      if (!action.NotUserAction && state.disabledIds.has(action.id)) return state;
+      if (!action.NotUserAction && state.disabledIds.has(action.id))
+        return state;
       let selectedIds;
       if (action.multiSelect) {
         selectedIds = new Set<NodeId>(state.selectedIds);
@@ -216,7 +217,8 @@ export const treeReducer = (
       };
     }
     case treeTypes.deselect: {
-      if (!action.NotUserAction && state.disabledIds.has(action.id)) return state;
+      if (!action.NotUserAction && state.disabledIds.has(action.id))
+        return state;
       const selectedIds = new Set<NodeId>(state.selectedIds);
       selectedIds.delete(action.id);
       let halfSelectedIds;
@@ -314,7 +316,13 @@ export const treeReducer = (
         selectedIds = new Set<NodeId>(action.ids);
       } else {
         selectedIds = new Set<NodeId>();
-        selectedIds.add(action.ids[action.ids.length - 1]);
+        if (action.ids.length > 1) {
+          console.warn(
+            "Tree in singleSelect mode, only the first item from selectedIds will be selected."
+          );
+        }
+        const idToAdd = action.ids[0];
+        idToAdd && selectedIds.add(idToAdd);
       }
 
       const halfSelectedIds = new Set<NodeId>(state.halfSelectedIds);

--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -396,6 +396,20 @@ export const isBranchSelectedAndHasSelectedDescendants = (
   );
 };
 
+export const isBranchNotSelectedAndHasAllSelectedDescendants = (
+  data: INode[],
+  elementId: NodeId,
+  selectedIds: Set<NodeId>
+) => {
+  return (
+    isBranchNode(data, elementId) &&
+    !selectedIds.has(elementId) &&
+    getDescendants(data, elementId, new Set<number>()).every((item) =>
+      selectedIds.has(item)
+    )
+  );
+};
+
 export const getTreeParent = (data: INode[]): INode => {
   const parentNode: INode | undefined = data.find(
     (node) => node.parent === null
@@ -435,7 +449,9 @@ export const validateTreeViewData = (data: INode[]): void => {
       throw Error(`Node with id=${node.id} has parent reference to itself.`);
     }
     if (hasDuplicates(node.children)) {
-      throw Error(`Node with id=${node.id} contains duplicate ids in its children.`);
+      throw Error(
+        `Node with id=${node.id} contains duplicate ids in its children.`
+      );
     }
   });
 

--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -410,6 +410,20 @@ export const isBranchNotSelectedAndHasAllSelectedDescendants = (
   );
 };
 
+export const isBranchSelectedAndHasAllSelectedDescendants = (
+  data: INode[],
+  elementId: NodeId,
+  selectedIds: Set<NodeId>
+) => {
+  return (
+    isBranchNode(data, elementId) &&
+    selectedIds.has(elementId) &&
+    getDescendants(data, elementId, new Set<number>()).every((item) =>
+      selectedIds.has(item)
+    )
+  );
+};
+
 export const getTreeParent = (data: INode[]): INode => {
   const parentNode: INode | undefined = data.find(
     (node) => node.parent === null

--- a/src/__tests__/CheckboxTree.test.tsx
+++ b/src/__tests__/CheckboxTree.test.tsx
@@ -187,41 +187,6 @@ test("propagateSelectUpwards half-selects all parent nodes in multiselect", () =
   expect(nodeLevel3Parents.length).toBe(2);
 });
 
-test("propagateSelectUpwards works correctly in single select", () => {
-  const { queryAllByRole, container } = render(
-    <CheckboxTree multiSelect={false} />
-  );
-  const nodes = queryAllByRole("treeitem");
-  nodes[1].focus();
-  if (document.activeElement == null)
-    throw new Error(
-      `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
-    );
-  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Drinks
-  fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); // Drinks group
-  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Apple Juice
-  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Chocolate
-  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Coffee
-  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Tea
-  fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); // Tea group
-  fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Black Tea
-  fireEvent.keyDown(document.activeElement, { key: "Enter" });
-
-  expect(container.querySelectorAll("[aria-checked='true']").length).toBe(1); // Black Tea
-  expect(container.querySelectorAll(".half-selected").length).toBe(2); // Drinks, Tea
-
-  //After selecting 1st level parent (Drinks) it should unselect 2nd (Tea) and 3rd level (Black Tea)
-  fireEvent.keyDown(document.activeElement, { key: "ArrowLeft" }); // Tea
-  fireEvent.keyDown(document.activeElement, { key: "ArrowLeft" }); // Tea collapsed
-  fireEvent.keyDown(document.activeElement, { key: "ArrowLeft" }); // Drinks group
-  fireEvent.keyDown(document.activeElement, { key: "ArrowLeft" }); // Drinks
-  fireEvent.keyDown(document.activeElement, { key: "Enter" });
-
-  expect(nodes[1]).toHaveAttribute("aria-checked", "true");
-  expect(container.querySelectorAll("[aria-checked='true']").length).toBe(1);
-  expect(container.querySelectorAll(".half-selected").length).toBe(0);
-});
-
 test("parent with selected descendants should be half-selected or checked in multiselect with propagateSelect={false}", () => {
   const { queryAllByRole, container } = render(
     <CheckboxTree propagateSelect={false} />

--- a/src/__tests__/SingleSelectCheckboxTree.test.tsx
+++ b/src/__tests__/SingleSelectCheckboxTree.test.tsx
@@ -1,0 +1,206 @@
+import "@testing-library/jest-dom/extend-expect";
+import { fireEvent, render } from "@testing-library/react";
+import React from "react";
+import TreeView, { flattenTree } from "..";
+
+const folder = {
+  name: "",
+  children: [
+    {
+      name: "Fruits",
+      children: [
+        { name: "Avocados" },
+        { name: "Bananas" },
+        { name: "Berries" },
+        { name: "Oranges" },
+        { name: "Pears" },
+      ],
+    },
+    {
+      name: "Drinks",
+      children: [
+        { name: "Apple Juice" },
+        { name: "Chocolate" },
+        { name: "Coffee" },
+        {
+          name: "Tea",
+          children: [
+            { name: "Black Tea" },
+            { name: "Green Tea" },
+            { name: "Red Tea" },
+            { name: "Matcha" },
+          ],
+        },
+      ],
+    },
+    {
+      name: "Vegetables",
+      children: [{ name: "Beets" }],
+    },
+  ],
+};
+
+const data = flattenTree(folder);
+
+function SingleSelectCheckboxTree() {
+  return (
+    <div>
+      <div className="checkbox">
+        <TreeView
+          data={data}
+          aria-label="Single select"
+          multiSelect={false}
+          propagateSelect
+          propagateSelectUpwards
+          togglableSelect
+          nodeAction="check"
+          nodeRenderer={({
+            element,
+            getNodeProps,
+            handleSelect,
+            handleExpand,
+            isHalfSelected,
+          }) => {
+            return (
+              <div
+                {...getNodeProps({ onClick: handleExpand })}
+                className={`${isHalfSelected ? "half-selected" : ""}`}
+              >
+                <div
+                  className="checkbox-icon"
+                  onClick={(e) => {
+                    handleSelect(e);
+                    e.stopPropagation();
+                  }}
+                />
+                <span className="name">{element.name}</span>
+              </div>
+            );
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+describe("Single select", () => {
+  test("PropagateSelectUpwards works correctly in single select", () => {
+    const { queryAllByRole, container } = render(<SingleSelectCheckboxTree />);
+    const nodes = queryAllByRole("treeitem");
+    nodes[1].focus();
+    if (document.activeElement == null)
+      throw new Error(
+        `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
+      );
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Drinks
+    fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); // Drinks group
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Apple Juice
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Chocolate
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Coffee
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Tea
+    fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); // Tea group
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Black Tea
+    fireEvent.keyDown(document.activeElement, { key: "Enter" });
+
+    expect(container.querySelectorAll("[aria-checked='true']").length).toBe(1); // Black Tea
+    expect(container.querySelectorAll(".half-selected").length).toBe(2); // Drinks, Tea
+
+    //After selecting 1st level parent (Drinks) it should unselect 2nd (Tea) and 3rd level (Black Tea)
+    fireEvent.keyDown(document.activeElement, { key: "ArrowLeft" }); // Tea
+    fireEvent.keyDown(document.activeElement, { key: "ArrowLeft" }); // Tea collapsed
+    fireEvent.keyDown(document.activeElement, { key: "ArrowLeft" }); // Drinks group
+    fireEvent.keyDown(document.activeElement, { key: "ArrowLeft" }); // Drinks
+    fireEvent.keyDown(document.activeElement, { key: "Enter" });
+
+    expect(nodes[1]).toHaveAttribute("aria-checked", "true");
+    expect(container.querySelectorAll("[aria-checked='true']").length).toBe(1);
+    expect(container.querySelectorAll(".half-selected").length).toBe(0);
+  });
+
+  test("propagateSelectUpward should select parent when the only child is selected", () => {
+    const { queryAllByRole, container } = render(<SingleSelectCheckboxTree />);
+    const nodes = queryAllByRole("treeitem");
+
+    expect(nodes.length).toBe(3);
+
+    nodes[0].focus();
+    if (document.activeElement == null)
+      throw new Error(
+        `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
+      );
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Fruits
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Drinks
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Vegetables
+    fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); // Vegetables group
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Beets
+    fireEvent.keyDown(document.activeElement, { key: "Enter" });
+
+    const expandedNodes = queryAllByRole("treeitem");
+
+    expect(expandedNodes[2].innerHTML).toContain("Vegetables");
+    expect(expandedNodes[3].innerHTML).toContain("Beets");
+    expect(expandedNodes[2]).toHaveAttribute("aria-checked", "true");
+    expect(expandedNodes[3]).toHaveAttribute("aria-checked", "true");
+    expect(container.querySelectorAll("[aria-checked='true']").length).toBe(2);
+  });
+
+  test.only('should unselect selected with propagation parent if it has only one selected child', () => {
+    const { queryAllByRole, container } = render(<SingleSelectCheckboxTree />);
+    const nodes = queryAllByRole("treeitem");
+
+    nodes[0].focus();
+    if (document.activeElement == null)
+      throw new Error(
+        `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
+      );
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Fruits
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Drinks
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Vegetables
+    fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); // Vegetables group
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Beets
+    fireEvent.keyDown(document.activeElement, { key: "Enter" });
+
+    const expandedNodes = queryAllByRole("treeitem");
+
+    expect(expandedNodes[2]).toHaveAttribute("aria-checked", "true");
+    expect(expandedNodes[3]).toHaveAttribute("aria-checked", "true");
+    expect(container.querySelectorAll("[aria-checked='true']").length).toBe(2);
+
+    fireEvent.keyDown(document.activeElement, { key: "ArrowUp" }); // Vegetables
+    fireEvent.keyDown(document.activeElement, { key: "Enter" });
+
+    const uncheckedNodes = queryAllByRole("treeitem");
+
+    expect(uncheckedNodes[2]).not.toHaveAttribute("aria-checked");
+    expect(uncheckedNodes[3]).not.toHaveAttribute("aria-checked");
+    expect(container.querySelectorAll("[aria-checked='true']").length).toBe(0);
+  });
+
+  test("should select only one node in a tree", () => {
+    const { queryAllByRole, container } = render(<SingleSelectCheckboxTree />);
+    const nodes = queryAllByRole("treeitem");
+    nodes[0].focus();
+    if (document.activeElement == null)
+      throw new Error(
+        `Expected to find an active element on the document (after focusing the second element with role["treeitem"]), but did not.`
+      );
+    fireEvent.keyDown(document.activeElement, { key: "Enter" });
+
+    expect(nodes[0]).toHaveAttribute("aria-checked", "true");
+    expect(container.querySelectorAll("[aria-checked='true']").length).toBe(1);
+
+    fireEvent.keyDown(document.activeElement, { key: "ArrowRight" }); // Fruits Group
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Avocados
+    fireEvent.keyDown(document.activeElement, { key: "ArrowDown" }); // Bananas
+    fireEvent.keyDown(document.activeElement, { key: "Enter" });
+
+    const newNodes = queryAllByRole("treeitem");
+
+    newNodes.forEach(node => console.log(node.innerHTML));
+
+    expect(newNodes.length).toBe(8);
+    expect(newNodes[0]).toHaveAttribute("aria-checked", "mixed");
+    expect(newNodes[2]).toHaveAttribute("aria-checked", "true");
+    expect(container.querySelectorAll("[aria-checked='true']").length).toBe(1);
+  });
+});

--- a/src/__tests__/SingleSelectCheckboxTree.test.tsx
+++ b/src/__tests__/SingleSelectCheckboxTree.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/extend-expect";
 import { fireEvent, render } from "@testing-library/react";
 import React from "react";
-import TreeView, { flattenTree } from "..";
+import TreeView, { NodeId, flattenTree } from "..";
 
 const folder = {
   name: "",
@@ -42,7 +42,11 @@ const folder = {
 
 const data = flattenTree(folder);
 
-function SingleSelectCheckboxTree() {
+function SingleSelectCheckboxTree({
+  selectedIds = [],
+}: {
+  selectedIds?: NodeId[];
+}) {
   return (
     <div>
       <div className="checkbox">
@@ -50,6 +54,7 @@ function SingleSelectCheckboxTree() {
           data={data}
           aria-label="Single select"
           multiSelect={false}
+          selectedIds={selectedIds}
           propagateSelect
           propagateSelectUpwards
           togglableSelect
@@ -144,7 +149,7 @@ describe("Single select", () => {
     expect(container.querySelectorAll("[aria-checked='true']").length).toBe(2);
   });
 
-  test.only('should unselect selected with propagation parent if it has only one selected child', () => {
+  test("should unselect selected with propagation parent if it has only one selected child", () => {
     const { queryAllByRole, container } = render(<SingleSelectCheckboxTree />);
     const nodes = queryAllByRole("treeitem");
 
@@ -196,11 +201,24 @@ describe("Single select", () => {
 
     const newNodes = queryAllByRole("treeitem");
 
-    newNodes.forEach(node => console.log(node.innerHTML));
+    newNodes.forEach((node) => console.log(node.innerHTML));
 
     expect(newNodes.length).toBe(8);
     expect(newNodes[0]).toHaveAttribute("aria-checked", "mixed");
     expect(newNodes[2]).toHaveAttribute("aria-checked", "true");
     expect(container.querySelectorAll("[aria-checked='true']").length).toBe(1);
+  });
+
+  test("should set and clear selectedIds", () => {
+    const { queryAllByRole, rerender, container } = render(
+      <SingleSelectCheckboxTree selectedIds={[1]} />
+    );
+    const nodes = queryAllByRole("treeitem");
+
+    expect(nodes[0]).toHaveAttribute("aria-checked", "true");
+
+    rerender(<SingleSelectCheckboxTree selectedIds={[]} />);
+
+    expect(container.querySelectorAll("[aria-checked='true']").length).toBe(0);
   });
 });

--- a/website/docs/examples/ControlledExpandedNode/index.js
+++ b/website/docs/examples/ControlledExpandedNode/index.js
@@ -62,6 +62,7 @@ function ControlledExpandedNode() {
       document
         .querySelector("#txtIdsToExpand")
         .value.split(",")
+        .filter(val => !!val.trim())
         .map((x) => {
           if (isNaN(parseInt(x.trim()))) {
             return x;

--- a/website/docs/examples/MultiSelectCheckboxControlled/index.js
+++ b/website/docs/examples/MultiSelectCheckboxControlled/index.js
@@ -64,6 +64,7 @@ function MultiSelectCheckboxControlled() {
       document
         .querySelector("#txtIdsToSelect")
         .value.split(",")
+        .filter(val => !!val.trim())
         .map((x) => {
           if (isNaN(parseInt(x.trim()))) {
             return x;

--- a/website/docs/examples/SingleSelectCheckbox/index.js
+++ b/website/docs/examples/SingleSelectCheckbox/index.js
@@ -52,11 +52,11 @@ function SingleSelectCheckbox() {
       <div className="checkbox">
         <TreeView
           data={data}
-          aria-label="Checkbox tree"
-          defaultExpandedIds={[16]}
+          aria-label="Single select"
           multiSelect={false}
           propagateSelectUpwards
           togglableSelect
+          nodeAction="check"
           nodeRenderer={({
             element,
             isBranch,

--- a/website/docs/examples/SingleSelectCheckbox/index.js
+++ b/website/docs/examples/SingleSelectCheckbox/index.js
@@ -1,0 +1,121 @@
+import React from "react";
+import { FaSquare, FaCheckSquare, FaMinusSquare } from "react-icons/fa";
+import { IoMdArrowDropright } from "react-icons/io";
+import TreeView, { flattenTree } from "react-accessible-treeview";
+import cx from "classnames";
+import "./styles.css";
+
+const folder = {
+  name: "",
+  children: [
+    {
+      name: "Fruits",
+      children: [
+        { name: "Avocados" },
+        { name: "Bananas" },
+        { name: "Berries" },
+        { name: "Oranges" },
+        { name: "Pears" },
+      ],
+    },
+    {
+      name: "Drinks",
+      children: [
+        { name: "Apple Juice" },
+        { name: "Chocolate" },
+        { name: "Coffee" },
+        {
+          name: "Tea",
+          children: [
+            { name: "Black Tea" },
+            { name: "Green Tea" },
+            { name: "Red Tea" },
+            { name: "Matcha" },
+          ],
+        },
+      ],
+    },
+    {
+      name: "Vegetables",
+      children: [
+        { name: "Beets" },
+      ],
+    },
+  ],
+};
+
+const data = flattenTree(folder);
+
+function SingleSelectCheckbox() {
+  return (
+    <div>
+      <div className="checkbox">
+        <TreeView
+          data={data}
+          aria-label="Checkbox tree"
+          defaultExpandedIds={[16]}
+          multiSelect={false}
+          propagateSelectUpwards
+          togglableSelect
+          nodeRenderer={({
+            element,
+            isBranch,
+            isExpanded,
+            isSelected,
+            isHalfSelected,
+            getNodeProps,
+            level,
+            handleSelect,
+            handleExpand,
+          }) => {
+            return (
+              <div
+                {...getNodeProps({ onClick: handleExpand })}
+                style={{ marginLeft: 40 * (level - 1) }}
+              >
+                {isBranch && <ArrowIcon isOpen={isExpanded} />}
+                <CheckBoxIcon
+                  className="checkbox-icon"
+                  onClick={(e) => {
+                    handleSelect(e);
+                    e.stopPropagation();
+                  }}
+                  variant={
+                    isHalfSelected ? "some" : isSelected ? "all" : "none"
+                  }
+                />
+                <span className="name">{element.name}-{element.id}</span>
+              </div>
+            );
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+const ArrowIcon = ({ isOpen, className }) => {
+  const baseClass = "arrow";
+  const classes = cx(
+    baseClass,
+    { [`${baseClass}--closed`]: !isOpen },
+    { [`${baseClass}--open`]: isOpen },
+    className
+  );
+  return <IoMdArrowDropright className={classes} />;
+};
+
+const CheckBoxIcon = ({ variant, ...rest }) => {
+  switch (variant) {
+    case "all":
+      return <FaCheckSquare {...rest} />;
+    case "none":
+      return <FaSquare {...rest} />;
+    case "some":
+      return <FaMinusSquare {...rest} />;
+    default:
+      return null;
+  }
+};
+
+export default SingleSelectCheckbox;

--- a/website/docs/examples/SingleSelectCheckbox/styles.css
+++ b/website/docs/examples/SingleSelectCheckbox/styles.css
@@ -1,0 +1,56 @@
+.checkbox {
+  font-size: 16px;
+  user-select: none;
+  min-height: 320px;
+  padding: 20px;
+  box-sizing: content-box;
+}
+
+.checkbox .tree,
+.checkbox .tree-node,
+.checkbox .tree-node-group {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.checkbox .tree-branch-wrapper,
+.checkbox .tree-node__leaf {
+  outline: none;
+}
+
+.checkbox .tree-node {
+  cursor: pointer;
+}
+
+.checkbox .tree-node .name:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.checkbox .tree-node--focused .name {
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.checkbox .tree-node {
+  display: inline-block;
+}
+
+.checkbox .checkbox-icon {
+  margin: 0 5px;
+  vertical-align: middle;
+}
+
+.checkbox button {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.checkbox .arrow {
+  margin-left: 5px;
+  vertical-align: middle;
+}
+
+.checkbox .arrow--open {
+  transform: rotate(90deg);
+}


### PR DESCRIPTION
Issue: When Tree is used in single select mode, if a node has a single child, and that child is selected, the parent ends up selected instead of the child. Additionally when there is only one child node for a few levels, the highest level ends up selected.

Ref: UIEN-4151