### PR TITLE
Fix error thrown during propagation run after data mutates.

### DIFF
--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -308,6 +308,16 @@ const useTree = ({
       ) {
         idsToUpdate.add(lastInteractedWith);
       }
+      //========START FILTER OUT NOT EXISTING IDS=========
+      // This block of code filters out from propagation check ids that aren't in data anymore
+      const idsNotInData: NodeId[] = [];
+      idsToUpdate.forEach((idToUpdate) => {
+        if (!data.find((node) => node.id === idToUpdate)) {
+          idsNotInData.push(idToUpdate);
+        }
+      });
+      idsNotInData.forEach((id) => idsToUpdate.delete(id));
+      //========END FILTER OUT NOT EXISTING IDS===========
       const { every, some, none } = propagateSelectChange(
         data,
         idsToUpdate,


### PR DESCRIPTION
The issue is: Tree component throws unexpected error if previously selected node is not present in data.
The fix is: In propagation effect filter out not existing in data ids from idsToUpdate.

Ref: UIEN-4269