### PR TITLE
Expand scope of node `metadata`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ An array of nodes. Nodes are objects with the following structure:
 | `children` | `array[id]`          | required | An array with the ids of the children nodes.                                                        |
 | `parent`   | `id`                 | required | The parent of the node. `null` for the root node                                                    |
 | `isBranch` | `boolean`            | optional | Used to indicated whether a node is branch to be able load async data onExpand, default is false    |
-| `metadata` | `object`             | optional | Used to add metadata into node object. We do not currently support metadata that is a nested object |
+| `metadata` | `any`                | optional | Used to add metadata into node object |
 
 The item with `parent:null` of the array represents the root node and won't be displayed.
 

--- a/src/TreeView/README.md
+++ b/src/TreeView/README.md
@@ -44,7 +44,7 @@ An array of nodes. Nodes are objects with the following structure:
 | `children` | `array[id]`          | required | An array with the ids of the children nodes.                                                        |
 | `parent`   | `id`                 | required | The parent of the node. `null` for the root node                                                    |
 | `isBranch` | `boolean`            | optional | Used to indicated whether a node is branch to be able load async data onExpand, default is false    |
-| `metadata` | `object`             | optional | Used to add metadata into node object. We do not currently support metadata that is a nested object |
+| `metadata` | `any`                | optional | Used to add metadata into node object |
 
 The item with `parent:null` of the array represents the root node and won't be displayed.
 

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -76,7 +76,7 @@ interface IUseTreeProps<M = unknown> {
   togglableSelect?: boolean;
 }
 
-// TS can"t differentiate between JSX and generics in TSX unless we extend something
+// TS can't differentiate between JSX and generics in TSX unless we extend something
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
 const useTree = <M extends unknown = unknown>({
   data,
@@ -319,7 +319,7 @@ const useTree = <M extends unknown = unknown>({
         idsToUpdate.add(lastInteractedWith);
       }
       //========START FILTER OUT NOT EXISTING IDS=========
-      // This block of code filters out from propagation check ids that aren"t in data anymore
+      // This block of code filters out from propagation check ids that aren't in data anymore
       const idsNotInData: NodeId[] = [];
       idsToUpdate.forEach((idToUpdate) => {
         if (!data.find((node) => node.id === idToUpdate)) {
@@ -488,7 +488,7 @@ export interface ITreeViewProps<M = unknown> {
   togglableSelect?: boolean;
   /** action to perform on click */
   clickAction?: ClickActions;
-  /** Custom onBlur event that is triggered when focusing out of the component as a whole (moving focus between the nodes won"t trigger it) */
+  /** Custom onBlur event that is triggered when focusing out of the component as a whole (moving focus between the nodes won't trigger it) */
   onBlur?: (event: {
     treeState: ITreeViewState;
     dispatch: React.Dispatch<TreeViewAction>;
@@ -621,7 +621,7 @@ const TreeView = React.forwardRef<HTMLUListElement, ITreeViewProps>(
   }
 ) as TreeViewComponent;
 
-// TS can"t differentiate between JSX and generics in TSX unless we extend something
+// TS can't differentiate between JSX and generics in TSX unless we extend something
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
 const handleKeyDown = <M extends unknown = unknown>({
   data,
@@ -664,8 +664,8 @@ const handleKeyDown = <M extends unknown = unknown>({
         type: treeTypes.changeSelectMany,
         multiSelect,
         select:
-          Array.from(selectedIds).filter((id) => !disabledIds.has(id)).length !==
-          ids.length,
+          Array.from(selectedIds).filter((id) => !disabledIds.has(id))
+            .length !== ids.length,
         ids,
         lastInteractedWith: element.id,
       });
@@ -996,7 +996,7 @@ TreeView.propTypes = {
   clickAction: PropTypes.oneOf(CLICK_ACTIONS),
 
   /** Custom onBlur event that is triggered when focusing out of the component
-   * as a whole (moving focus between the nodes won"t trigger it) */
+   * as a whole (moving focus between the nodes won't trigger it) */
   onBlur: PropTypes.func,
 
   /** Function called to load data asynchronously on expand */

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -17,7 +17,6 @@ import {
 } from './reducer';
 import {
   ClickActions,
-  IMetadata,
   INode,
   INodeRefs,
   INodeRendererProps,
@@ -57,7 +56,7 @@ import {
   NODE_ACTIONS,
 } from './constants';
 
-interface IUseTreeProps<M = IMetadata> {
+interface IUseTreeProps<M = unknown> {
   data: INode<M>[];
   controlledSelectedIds?: NodeId[];
   controlledExpandedIds?: NodeId[];
@@ -79,7 +78,7 @@ interface IUseTreeProps<M = IMetadata> {
 
 // TS can't differentiate between JSX and generics in TSX unless we extend something
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
-const useTree = <M extends unknown = IMetadata>({
+const useTree = <M extends unknown = unknown>({
   data,
   controlledSelectedIds,
   controlledExpandedIds,
@@ -412,7 +411,7 @@ const useTree = <M extends unknown = IMetadata>({
   return [state, dispatch] as const;
 };
 
-export interface ITreeViewOnSelectProps<M = IMetadata> {
+export interface ITreeViewOnSelectProps<M = unknown> {
   element: INode<M>;
   isBranch: boolean;
   isExpanded: boolean;
@@ -422,14 +421,14 @@ export interface ITreeViewOnSelectProps<M = IMetadata> {
   treeState: ITreeViewState;
 }
 
-export interface ITreeViewOnNodeSelectProps<M = IMetadata> {
+export interface ITreeViewOnNodeSelectProps<M = unknown> {
   element: INode<M>;
   isSelected: boolean;
   isBranch: boolean;
   treeState?: ITreeViewState;
 }
 
-export interface ITreeViewOnExpandProps<M = IMetadata> {
+export interface ITreeViewOnExpandProps<M = unknown> {
   element: INode<M>;
   isExpanded: boolean;
   isSelected: boolean;
@@ -438,7 +437,7 @@ export interface ITreeViewOnExpandProps<M = IMetadata> {
   treeState: ITreeViewState;
 }
 
-export interface ITreeViewOnLoadDataProps<M = IMetadata> {
+export interface ITreeViewOnLoadDataProps<M = unknown> {
   element: INode<M>;
   isExpanded: boolean;
   isSelected: boolean;
@@ -447,7 +446,7 @@ export interface ITreeViewOnLoadDataProps<M = IMetadata> {
   treeState: ITreeViewState;
 }
 
-export interface ITreeViewProps<M = IMetadata> {
+export interface ITreeViewProps<M = unknown> {
   /** Tree data*/
   data: INode<M>[];
   /** Function called when a node changes its selected state */
@@ -494,6 +493,14 @@ export interface ITreeViewProps<M = IMetadata> {
     treeState: ITreeViewState;
     dispatch: React.Dispatch<TreeViewAction>;
   }) => void;
+}
+
+interface TreeViewComponent {
+  <M = unknown>(
+    props: PropsWithoutRef<ITreeViewProps<M>>,
+    ref: RefAttributes<HTMLUListElement>
+  ): ReactElement | null;
+  propTypes: WeakValidationMap<PropsWithoutRef<ITreeViewProps>>;
 }
 
 const TreeView = React.forwardRef<HTMLUListElement, ITreeViewProps>(
@@ -612,18 +619,11 @@ const TreeView = React.forwardRef<HTMLUListElement, ITreeViewProps>(
       </ul>
     );
   }
-  // TS can't differentiate between JSX and generics in TSX unless we extend something
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
-) as (<M extends unknown = IMetadata>(
-  props: PropsWithoutRef<ITreeViewProps<M>>,
-  ref: RefAttributes<HTMLUListElement>
-) => ReactElement | null) & {
-  propTypes: WeakValidationMap<PropsWithoutRef<ITreeViewProps>>;
-};
+) as TreeViewComponent;
 
 // TS can't differentiate between JSX and generics in TSX unless we extend something
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
-const handleKeyDown = <M extends unknown = IMetadata>({
+const handleKeyDown = <M extends unknown = unknown>({
   data,
   expandedIds,
   selectedIds,

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -1,5 +1,5 @@
-import cx from "classnames";
-import PropTypes from "prop-types";
+import cx from 'classnames';
+import PropTypes from 'prop-types';
 import React, {
   useEffect,
   useReducer,
@@ -7,13 +7,14 @@ import React, {
   PropsWithoutRef,
   RefAttributes,
   ReactElement,
-} from "react";
+  WeakValidationMap,
+} from 'react';
 import {
   ITreeViewState,
   treeReducer,
   treeTypes,
   TreeViewAction,
-} from "./reducer";
+} from './reducer';
 import {
   ClickActions,
   IMetadata,
@@ -22,7 +23,7 @@ import {
   INodeRendererProps,
   NodeAction,
   NodeId,
-} from "./types";
+} from './types';
 import {
   difference,
   focusRef,
@@ -47,14 +48,14 @@ import {
   noop,
   isBranchNotSelectedAndHasOnlySelectedChild,
   isBranchSelectedAndHasOnlySelectedChild,
-} from "./utils";
-import { Node } from "./node";
+} from './utils';
+import { Node } from './node';
 import {
   baseClassNames,
   clickActions,
   CLICK_ACTIONS,
   NODE_ACTIONS,
-} from "./constants";
+} from './constants';
 
 interface IUseTreeProps<M = IMetadata> {
   data: INode<M>[];
@@ -321,12 +322,12 @@ const useTree = <M extends unknown = IMetadata>({
       //========START FILTER OUT NOT EXISTING IDS=========
       // This block of code filters out from propagation check ids that aren't in data anymore
       const idsNotInData: NodeId[] = [];
-      idsToUpdate.forEach((idToUpdate) => {
-        if (!data.find((node) => node.id === idToUpdate)) {
+      idsToUpdate.forEach(idToUpdate => {
+        if (!data.find(node => node.id === idToUpdate)) {
           idsNotInData.push(idToUpdate);
         }
       });
-      idsNotInData.forEach((id) => idsToUpdate.delete(id));
+      idsNotInData.forEach(id => idsToUpdate.delete(id));
       //========END FILTER OUT NOT EXISTING IDS===========
       const { every, some, none } = propagateSelectChange(
         data,
@@ -505,7 +506,7 @@ const TreeView = React.forwardRef<HTMLUListElement, ITreeViewProps>(
       onNodeSelect = noop,
       onExpand = noop,
       onLoadData,
-      className = "",
+      className = '',
       multiSelect = false,
       propagateSelect = false,
       propagateSelectUpwards = false,
@@ -516,7 +517,7 @@ const TreeView = React.forwardRef<HTMLUListElement, ITreeViewProps>(
       defaultSelectedIds = [],
       defaultDisabledIds = [],
       clickAction = clickActions.select,
-      nodeAction = "select",
+      nodeAction = 'select',
       expandedIds,
       onBlur,
       ...other
@@ -555,9 +556,9 @@ const TreeView = React.forwardRef<HTMLUListElement, ITreeViewProps>(
       <ul
         className={cx(baseClassNames.root, className)}
         role="tree"
-        aria-multiselectable={nodeAction === "select" ? multiSelect : undefined}
+        aria-multiselectable={nodeAction === 'select' ? multiSelect : undefined}
         ref={innerRef}
-        onBlur={(event) => {
+        onBlur={event => {
           onComponentBlur(event, innerRef.current, () => {
             onBlur &&
               onBlur({
@@ -613,10 +614,12 @@ const TreeView = React.forwardRef<HTMLUListElement, ITreeViewProps>(
   }
   // TS can't differentiate between JSX and generics in TSX unless we extend something
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
-) as <M extends unknown = IMetadata>(
+) as (<M extends unknown = IMetadata>(
   props: PropsWithoutRef<ITreeViewProps<M>>,
   ref: RefAttributes<HTMLUListElement>
-) => ReactElement | null;
+) => ReactElement | null) & {
+  propTypes: WeakValidationMap<PropsWithoutRef<ITreeViewProps>>;
+};
 
 // TS can't differentiate between JSX and generics in TSX unless we extend something
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
@@ -651,27 +654,27 @@ const handleKeyDown = <M extends unknown = IMetadata>({
   const element = getTreeNode(data, tabbableId);
   const id = element.id;
   if (event.ctrlKey) {
-    if (event.key === "a") {
+    if (event.key === 'a') {
       event.preventDefault();
-      const dataWithoutRoot = data.filter((x) => x.parent !== null);
+      const dataWithoutRoot = data.filter(x => x.parent !== null);
       const ids = dataWithoutRoot
-        .map((x) => x.id)
-        .filter((id) => !disabledIds.has(id));
+        .map(x => x.id)
+        .filter(id => !disabledIds.has(id));
       dispatch({
         type: treeTypes.changeSelectMany,
         multiSelect,
         select:
-          Array.from(selectedIds).filter((id) => !disabledIds.has(id))
-            .length !== ids.length,
+          Array.from(selectedIds).filter(id => !disabledIds.has(id)).length !==
+          ids.length,
         ids,
         lastInteractedWith: element.id,
       });
     } else if (
       event.shiftKey &&
-      (event.key === "Home" || event.key === "End")
+      (event.key === 'Home' || event.key === 'End')
     ) {
       const newId =
-        event.key === "Home"
+        event.key === 'Home'
           ? getTreeParent(data).children[0]
           : getLastAccessible(data, id, expandedIds);
       const range = getAccessibleRange({
@@ -679,7 +682,7 @@ const handleKeyDown = <M extends unknown = IMetadata>({
         expandedIds,
         from: id,
         to: newId,
-      }).filter((id) => !disabledIds.has(id));
+      }).filter(id => !disabledIds.has(id));
       dispatch({
         type: treeTypes.changeSelectMany,
         multiSelect,
@@ -697,7 +700,7 @@ const handleKeyDown = <M extends unknown = IMetadata>({
 
   if (event.shiftKey) {
     switch (event.key) {
-      case "ArrowUp": {
+      case 'ArrowUp': {
         event.preventDefault();
         const previous = getPreviousAccessible(data, id, expandedIds);
         if (previous != null && !disabledIds.has(previous)) {
@@ -719,7 +722,7 @@ const handleKeyDown = <M extends unknown = IMetadata>({
         }
         return;
       }
-      case "ArrowDown": {
+      case 'ArrowDown': {
         event.preventDefault();
         const next = getNextAccessible(data, id, expandedIds);
         if (next != null && !disabledIds.has(next)) {
@@ -746,7 +749,7 @@ const handleKeyDown = <M extends unknown = IMetadata>({
     }
   }
   switch (event.key) {
-    case "ArrowDown": {
+    case 'ArrowDown': {
       event.preventDefault();
       const next = getNextAccessible(data, id, expandedIds);
       if (next != null) {
@@ -758,7 +761,7 @@ const handleKeyDown = <M extends unknown = IMetadata>({
       }
       return;
     }
-    case "ArrowUp": {
+    case 'ArrowUp': {
       event.preventDefault();
       const previous = getPreviousAccessible(data, id, expandedIds);
       if (previous != null) {
@@ -770,7 +773,7 @@ const handleKeyDown = <M extends unknown = IMetadata>({
       }
       return;
     }
-    case "ArrowLeft": {
+    case 'ArrowLeft': {
       event.preventDefault();
       if (
         (isBranchNode(data, id) || element.isBranch) &&
@@ -795,7 +798,7 @@ const handleKeyDown = <M extends unknown = IMetadata>({
         if (!isRoot) {
           const parentId = getParent(data, id);
           if (parentId == null) {
-            throw new Error("parentId of root element is null");
+            throw new Error('parentId of root element is null');
           }
           dispatch({
             type: treeTypes.focus,
@@ -806,7 +809,7 @@ const handleKeyDown = <M extends unknown = IMetadata>({
       }
       return;
     }
-    case "ArrowRight": {
+    case 'ArrowRight': {
       event.preventDefault();
       if (isBranchNode(data, id) || element.isBranch) {
         if (expandedIds.has(tabbableId)) {
@@ -821,7 +824,7 @@ const handleKeyDown = <M extends unknown = IMetadata>({
       }
       return;
     }
-    case "Home":
+    case 'Home':
       event.preventDefault();
       dispatch({
         type: treeTypes.focus,
@@ -829,7 +832,7 @@ const handleKeyDown = <M extends unknown = IMetadata>({
         lastInteractedWith: getTreeParent(data).children[0],
       });
       break;
-    case "End": {
+    case 'End': {
       event.preventDefault();
       const lastAccessible = getLastAccessible(
         data,
@@ -843,14 +846,14 @@ const handleKeyDown = <M extends unknown = IMetadata>({
       });
       return;
     }
-    case "*": {
+    case '*': {
       event.preventDefault();
       const parentId = getParent(data, id);
       if (parentId == null) {
-        throw new Error("parentId of element is null");
+        throw new Error('parentId of element is null');
       }
       const nodes = getTreeNode(data, parentId).children.filter(
-        (x) => isBranchNode(data, x) || getTreeNode(data, x).isBranch
+        x => isBranchNode(data, x) || getTreeNode(data, x).isBranch
       );
       dispatch({
         type: treeTypes.expandMany,
@@ -860,9 +863,9 @@ const handleKeyDown = <M extends unknown = IMetadata>({
       return;
     }
     //IE11 uses "Spacebar"
-    case "Enter":
-    case " ":
-    case "Spacebar":
+    case 'Enter':
+    case ' ':
+    case 'Spacebar':
       event.preventDefault();
 
       if (clickAction === clickActions.focus) {
@@ -932,9 +935,6 @@ const handleKeyDown = <M extends unknown = IMetadata>({
   }
 };
 
-// The `TreeView` typecast that enables metadata propagation can't also have a propTypes object due to the nature of the cast
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 TreeView.propTypes = {
   /** Tree data*/
   data: PropTypes.array.isRequired,

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -1,5 +1,5 @@
-import cx from 'classnames';
-import PropTypes from 'prop-types';
+import cx from "classnames";
+import PropTypes from "prop-types";
 import React, {
   useEffect,
   useReducer,
@@ -8,13 +8,13 @@ import React, {
   RefAttributes,
   ReactElement,
   WeakValidationMap,
-} from 'react';
+} from "react";
 import {
   ITreeViewState,
   treeReducer,
   treeTypes,
   TreeViewAction,
-} from './reducer';
+} from "./reducer";
 import {
   ClickActions,
   INode,
@@ -22,7 +22,7 @@ import {
   INodeRendererProps,
   NodeAction,
   NodeId,
-} from './types';
+} from "./types";
 import {
   difference,
   focusRef,
@@ -47,14 +47,14 @@ import {
   noop,
   isBranchNotSelectedAndHasOnlySelectedChild,
   isBranchSelectedAndHasOnlySelectedChild,
-} from './utils';
-import { Node } from './node';
+} from "./utils";
+import { Node } from "./node";
 import {
   baseClassNames,
   clickActions,
   CLICK_ACTIONS,
   NODE_ACTIONS,
-} from './constants';
+} from "./constants";
 
 interface IUseTreeProps<M = unknown> {
   data: INode<M>[];
@@ -76,7 +76,7 @@ interface IUseTreeProps<M = unknown> {
   togglableSelect?: boolean;
 }
 
-// TS can't differentiate between JSX and generics in TSX unless we extend something
+// TS can"t differentiate between JSX and generics in TSX unless we extend something
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
 const useTree = <M extends unknown = unknown>({
   data,
@@ -319,14 +319,14 @@ const useTree = <M extends unknown = unknown>({
         idsToUpdate.add(lastInteractedWith);
       }
       //========START FILTER OUT NOT EXISTING IDS=========
-      // This block of code filters out from propagation check ids that aren't in data anymore
+      // This block of code filters out from propagation check ids that aren"t in data anymore
       const idsNotInData: NodeId[] = [];
-      idsToUpdate.forEach(idToUpdate => {
-        if (!data.find(node => node.id === idToUpdate)) {
+      idsToUpdate.forEach((idToUpdate) => {
+        if (!data.find((node) => node.id === idToUpdate)) {
           idsNotInData.push(idToUpdate);
         }
       });
-      idsNotInData.forEach(id => idsToUpdate.delete(id));
+      idsNotInData.forEach((id) => idsToUpdate.delete(id));
       //========END FILTER OUT NOT EXISTING IDS===========
       const { every, some, none } = propagateSelectChange(
         data,
@@ -488,7 +488,7 @@ export interface ITreeViewProps<M = unknown> {
   togglableSelect?: boolean;
   /** action to perform on click */
   clickAction?: ClickActions;
-  /** Custom onBlur event that is triggered when focusing out of the component as a whole (moving focus between the nodes won't trigger it) */
+  /** Custom onBlur event that is triggered when focusing out of the component as a whole (moving focus between the nodes won"t trigger it) */
   onBlur?: (event: {
     treeState: ITreeViewState;
     dispatch: React.Dispatch<TreeViewAction>;
@@ -513,7 +513,7 @@ const TreeView = React.forwardRef<HTMLUListElement, ITreeViewProps>(
       onNodeSelect = noop,
       onExpand = noop,
       onLoadData,
-      className = '',
+      className = "",
       multiSelect = false,
       propagateSelect = false,
       propagateSelectUpwards = false,
@@ -524,7 +524,7 @@ const TreeView = React.forwardRef<HTMLUListElement, ITreeViewProps>(
       defaultSelectedIds = [],
       defaultDisabledIds = [],
       clickAction = clickActions.select,
-      nodeAction = 'select',
+      nodeAction = "select",
       expandedIds,
       onBlur,
       ...other
@@ -563,9 +563,9 @@ const TreeView = React.forwardRef<HTMLUListElement, ITreeViewProps>(
       <ul
         className={cx(baseClassNames.root, className)}
         role="tree"
-        aria-multiselectable={nodeAction === 'select' ? multiSelect : undefined}
+        aria-multiselectable={nodeAction === "select" ? multiSelect : undefined}
         ref={innerRef}
-        onBlur={event => {
+        onBlur={(event) => {
           onComponentBlur(event, innerRef.current, () => {
             onBlur &&
               onBlur({
@@ -621,7 +621,7 @@ const TreeView = React.forwardRef<HTMLUListElement, ITreeViewProps>(
   }
 ) as TreeViewComponent;
 
-// TS can't differentiate between JSX and generics in TSX unless we extend something
+// TS can"t differentiate between JSX and generics in TSX unless we extend something
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
 const handleKeyDown = <M extends unknown = unknown>({
   data,
@@ -654,27 +654,27 @@ const handleKeyDown = <M extends unknown = unknown>({
   const element = getTreeNode(data, tabbableId);
   const id = element.id;
   if (event.ctrlKey) {
-    if (event.key === 'a') {
+    if (event.key === "a") {
       event.preventDefault();
-      const dataWithoutRoot = data.filter(x => x.parent !== null);
+      const dataWithoutRoot = data.filter((x) => x.parent !== null);
       const ids = dataWithoutRoot
-        .map(x => x.id)
-        .filter(id => !disabledIds.has(id));
+        .map((x) => x.id)
+        .filter((id) => !disabledIds.has(id));
       dispatch({
         type: treeTypes.changeSelectMany,
         multiSelect,
         select:
-          Array.from(selectedIds).filter(id => !disabledIds.has(id)).length !==
+          Array.from(selectedIds).filter((id) => !disabledIds.has(id)).length !==
           ids.length,
         ids,
         lastInteractedWith: element.id,
       });
     } else if (
       event.shiftKey &&
-      (event.key === 'Home' || event.key === 'End')
+      (event.key === "Home" || event.key === "End")
     ) {
       const newId =
-        event.key === 'Home'
+        event.key === "Home"
           ? getTreeParent(data).children[0]
           : getLastAccessible(data, id, expandedIds);
       const range = getAccessibleRange({
@@ -682,7 +682,7 @@ const handleKeyDown = <M extends unknown = unknown>({
         expandedIds,
         from: id,
         to: newId,
-      }).filter(id => !disabledIds.has(id));
+      }).filter((id) => !disabledIds.has(id));
       dispatch({
         type: treeTypes.changeSelectMany,
         multiSelect,
@@ -700,7 +700,7 @@ const handleKeyDown = <M extends unknown = unknown>({
 
   if (event.shiftKey) {
     switch (event.key) {
-      case 'ArrowUp': {
+      case "ArrowUp": {
         event.preventDefault();
         const previous = getPreviousAccessible(data, id, expandedIds);
         if (previous != null && !disabledIds.has(previous)) {
@@ -722,7 +722,7 @@ const handleKeyDown = <M extends unknown = unknown>({
         }
         return;
       }
-      case 'ArrowDown': {
+      case "ArrowDown": {
         event.preventDefault();
         const next = getNextAccessible(data, id, expandedIds);
         if (next != null && !disabledIds.has(next)) {
@@ -749,7 +749,7 @@ const handleKeyDown = <M extends unknown = unknown>({
     }
   }
   switch (event.key) {
-    case 'ArrowDown': {
+    case "ArrowDown": {
       event.preventDefault();
       const next = getNextAccessible(data, id, expandedIds);
       if (next != null) {
@@ -761,7 +761,7 @@ const handleKeyDown = <M extends unknown = unknown>({
       }
       return;
     }
-    case 'ArrowUp': {
+    case "ArrowUp": {
       event.preventDefault();
       const previous = getPreviousAccessible(data, id, expandedIds);
       if (previous != null) {
@@ -773,7 +773,7 @@ const handleKeyDown = <M extends unknown = unknown>({
       }
       return;
     }
-    case 'ArrowLeft': {
+    case "ArrowLeft": {
       event.preventDefault();
       if (
         (isBranchNode(data, id) || element.isBranch) &&
@@ -798,7 +798,7 @@ const handleKeyDown = <M extends unknown = unknown>({
         if (!isRoot) {
           const parentId = getParent(data, id);
           if (parentId == null) {
-            throw new Error('parentId of root element is null');
+            throw new Error("parentId of root element is null");
           }
           dispatch({
             type: treeTypes.focus,
@@ -809,7 +809,7 @@ const handleKeyDown = <M extends unknown = unknown>({
       }
       return;
     }
-    case 'ArrowRight': {
+    case "ArrowRight": {
       event.preventDefault();
       if (isBranchNode(data, id) || element.isBranch) {
         if (expandedIds.has(tabbableId)) {
@@ -824,7 +824,7 @@ const handleKeyDown = <M extends unknown = unknown>({
       }
       return;
     }
-    case 'Home':
+    case "Home":
       event.preventDefault();
       dispatch({
         type: treeTypes.focus,
@@ -832,7 +832,7 @@ const handleKeyDown = <M extends unknown = unknown>({
         lastInteractedWith: getTreeParent(data).children[0],
       });
       break;
-    case 'End': {
+    case "End": {
       event.preventDefault();
       const lastAccessible = getLastAccessible(
         data,
@@ -846,14 +846,14 @@ const handleKeyDown = <M extends unknown = unknown>({
       });
       return;
     }
-    case '*': {
+    case "*": {
       event.preventDefault();
       const parentId = getParent(data, id);
       if (parentId == null) {
-        throw new Error('parentId of element is null');
+        throw new Error("parentId of element is null");
       }
       const nodes = getTreeNode(data, parentId).children.filter(
-        x => isBranchNode(data, x) || getTreeNode(data, x).isBranch
+        (x) => isBranchNode(data, x) || getTreeNode(data, x).isBranch
       );
       dispatch({
         type: treeTypes.expandMany,
@@ -863,9 +863,9 @@ const handleKeyDown = <M extends unknown = unknown>({
       return;
     }
     //IE11 uses "Spacebar"
-    case 'Enter':
-    case ' ':
-    case 'Spacebar':
+    case "Enter":
+    case " ":
+    case "Spacebar":
       event.preventDefault();
 
       if (clickAction === clickActions.focus) {
@@ -996,7 +996,7 @@ TreeView.propTypes = {
   clickAction: PropTypes.oneOf(CLICK_ACTIONS),
 
   /** Custom onBlur event that is triggered when focusing out of the component
-   * as a whole (moving focus between the nodes won't trigger it) */
+   * as a whole (moving focus between the nodes won"t trigger it) */
   onBlur: PropTypes.func,
 
   /** Function called to load data asynchronously on expand */

--- a/src/TreeView/node.tsx
+++ b/src/TreeView/node.tsx
@@ -4,6 +4,7 @@ import { ITreeViewState, treeTypes, TreeViewAction } from "./reducer";
 import {
   ClickActions,
   EventCallback,
+  IMetadata,
   INode,
   INodeRef,
   INodeRefs,
@@ -26,10 +27,10 @@ import {
 } from "./utils";
 import { baseClassNames, clickActions } from "./constants";
 
-export interface INodeProps {
-  element: INode;
+export interface INodeProps<M = IMetadata> {
+  element: INode<M>;
   dispatch: React.Dispatch<TreeViewAction>;
-  data: INode[];
+  data: INode<M>[];
   nodeAction: NodeAction;
   selectedIds: Set<NodeId>;
   tabbableId: NodeId;
@@ -41,7 +42,7 @@ export interface INodeProps {
   nodeRefs: INodeRefs;
   leafRefs: INodeRefs;
   baseClassNames: typeof baseClassNames;
-  nodeRenderer: (props: INodeRendererProps) => React.ReactNode;
+  nodeRenderer: (props: INodeRendererProps<M>) => React.ReactNode;
   setsize: number;
   posinset: number;
   level: number;
@@ -54,8 +55,8 @@ export interface INodeProps {
   propagateSelectUpwards: boolean;
 }
 
-export interface INodeGroupProps
-  extends Omit<INodeProps, "setsize" | "posinset"> {
+export interface INodeGroupProps<M = IMetadata>
+  extends Omit<INodeProps<M>, "setsize" | "posinset"> {
   getClasses: (className: string) => string;
   /** don't send this. The NodeGroup render function, determines it for you */
   setsize?: undefined;
@@ -66,15 +67,19 @@ export interface INodeGroupProps
 /**
  * It's convenient to pass props down to the child, but we don't want to pass everything since it would create incorrect values for setsize and posinset
  */
-const removeIrrelevantGroupProps = (
-  nodeProps: INodeProps
-): Omit<INodeGroupProps, "getClasses"> => {
+// TS can't differentiate between JSX and generics in TSX unless we extend something
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
+const removeIrrelevantGroupProps = <M extends unknown = IMetadata>(
+  nodeProps: INodeProps<M>
+): Omit<INodeGroupProps<M>, "getClasses"> => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { setsize, posinset, ...rest } = nodeProps;
   return rest;
 };
 
-export const Node = (props: INodeProps) => {
+// TS can't differentiate between JSX and generics in TSX unless we extend something
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
+export const Node = <M extends unknown = IMetadata>(props: INodeProps<M>) => {
   const {
     element,
     dispatch,
@@ -327,7 +332,9 @@ export const Node = (props: INodeProps) => {
   );
 };
 
-export const NodeGroup = ({
+// TS can't differentiate between JSX and generics in TSX unless we extend something
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
+export const NodeGroup = <M extends unknown = IMetadata>({
   data,
   element,
   expandedIds,
@@ -335,7 +342,7 @@ export const NodeGroup = ({
   baseClassNames,
   level,
   ...rest
-}: INodeGroupProps) => (
+}: INodeGroupProps<M>) => (
   <ul role="group" className={getClasses(baseClassNames.nodeGroup)}>
     {expandedIds.has(element.id) &&
       element.children.length > 0 &&

--- a/src/TreeView/node.tsx
+++ b/src/TreeView/node.tsx
@@ -4,7 +4,6 @@ import { ITreeViewState, treeTypes, TreeViewAction } from "./reducer";
 import {
   ClickActions,
   EventCallback,
-  IMetadata,
   INode,
   INodeRef,
   INodeRefs,
@@ -27,7 +26,7 @@ import {
 } from "./utils";
 import { baseClassNames, clickActions } from "./constants";
 
-export interface INodeProps<M = IMetadata> {
+export interface INodeProps<M = unknown> {
   element: INode<M>;
   dispatch: React.Dispatch<TreeViewAction>;
   data: INode<M>[];
@@ -55,7 +54,7 @@ export interface INodeProps<M = IMetadata> {
   propagateSelectUpwards: boolean;
 }
 
-export interface INodeGroupProps<M = IMetadata>
+export interface INodeGroupProps<M = unknown>
   extends Omit<INodeProps<M>, "setsize" | "posinset"> {
   getClasses: (className: string) => string;
   /** don't send this. The NodeGroup render function, determines it for you */
@@ -69,7 +68,7 @@ export interface INodeGroupProps<M = IMetadata>
  */
 // TS can't differentiate between JSX and generics in TSX unless we extend something
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
-const removeIrrelevantGroupProps = <M extends unknown = IMetadata>(
+const removeIrrelevantGroupProps = <M extends unknown = unknown>(
   nodeProps: INodeProps<M>
 ): Omit<INodeGroupProps<M>, "getClasses"> => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -79,7 +78,7 @@ const removeIrrelevantGroupProps = <M extends unknown = IMetadata>(
 
 // TS can't differentiate between JSX and generics in TSX unless we extend something
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
-export const Node = <M extends unknown = IMetadata>(props: INodeProps<M>) => {
+export const Node = <M extends unknown = unknown>(props: INodeProps<M>) => {
   const {
     element,
     dispatch,
@@ -107,7 +106,7 @@ export const Node = <M extends unknown = IMetadata>(props: INodeProps<M>) => {
     state,
   } = props;
 
-  const handleExpand: EventCallback = (event) => {
+  const handleExpand: EventCallback = event => {
     if (event.ctrlKey || event.altKey || event.shiftKey) return;
     if (expandedIds.has(element.id) && propagateCollapse) {
       const ids: NodeId[] = [
@@ -334,7 +333,7 @@ export const Node = <M extends unknown = IMetadata>(props: INodeProps<M>) => {
 
 // TS can't differentiate between JSX and generics in TSX unless we extend something
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
-export const NodeGroup = <M extends unknown = IMetadata>({
+export const NodeGroup = <M extends unknown = unknown>({
   data,
   element,
   expandedIds,

--- a/src/TreeView/node.tsx
+++ b/src/TreeView/node.tsx
@@ -106,7 +106,7 @@ export const Node = <M extends unknown = unknown>(props: INodeProps<M>) => {
     state,
   } = props;
 
-  const handleExpand: EventCallback = event => {
+  const handleExpand: EventCallback = (event) => {
     if (event.ctrlKey || event.altKey || event.shiftKey) return;
     if (expandedIds.has(element.id) && propagateCollapse) {
       const ids: NodeId[] = [

--- a/src/TreeView/types.ts
+++ b/src/TreeView/types.ts
@@ -1,6 +1,5 @@
 import { clickActions, nodeActions } from "./constants";
 import { ITreeViewState, TreeViewAction } from "./reducer";
-import { IFlatMetadata } from "./utils";
 
 export type ValueOf<T> = T[keyof T];
 export type ClickActions = ValueOf<typeof clickActions>;
@@ -16,9 +15,11 @@ export type INodeRefs = null | React.RefObject<{
 
 export type EventCallback = <T, E>(
   event: React.MouseEvent<T, E> | React.KeyboardEvent<T>
-  ) => void;
-  
-  export interface INode<M extends IFlatMetadata = IFlatMetadata> {
+) => void;
+
+export type IMetadata = undefined;
+
+  export interface INode<M = IMetadata> {
     /** A non-negative integer that uniquely identifies the node */
     id: NodeId;
     /** Used to match on key press */
@@ -33,9 +34,9 @@ export type EventCallback = <T, E>(
     metadata?: M;
   }
 
-  export interface INodeRendererProps {
+  export interface INodeRendererProps<M = IMetadata> {
     /** The object that represents the rendered node */
-    element: INode;
+    element: INode<M>;
     /** A function which gives back the props to pass to the node */
     getNodeProps: (args?: {
       onClick?: EventCallback;

--- a/src/TreeView/types.ts
+++ b/src/TreeView/types.ts
@@ -15,7 +15,7 @@ export type INodeRefs = null | React.RefObject<{
 
 export type EventCallback = <T, E>(
   event: React.MouseEvent<T, E> | React.KeyboardEvent<T>
-) => void;
+  ) => void;
 
 export type IMetadata = undefined;
 

--- a/src/TreeView/types.ts
+++ b/src/TreeView/types.ts
@@ -17,9 +17,7 @@ export type EventCallback = <T, E>(
   event: React.MouseEvent<T, E> | React.KeyboardEvent<T>
   ) => void;
 
-export type IMetadata = undefined;
-
-  export interface INode<M = IMetadata> {
+  export interface INode<M = unknown> {
     /** A non-negative integer that uniquely identifies the node */
     id: NodeId;
     /** Used to match on key press */
@@ -34,7 +32,7 @@ export type IMetadata = undefined;
     metadata?: M;
   }
 
-  export interface INodeRendererProps<M = IMetadata> {
+  export interface INodeRendererProps<M = unknown> {
     /** The object that represents the rendered node */
     element: INode<M>;
     /** A function which gives back the props to pass to the node */

--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { EventCallback, IMetadata, INode, INodeRef, NodeId } from "./types";
+import { EventCallback, INode, INodeRef, NodeId } from "./types";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export const noop = () => {};
@@ -37,7 +37,7 @@ export const usePrevious = (x: Set<NodeId>) => {
   return ref.current;
 };
 
-export const usePreviousData = <M = IMetadata>(value: INode<M>[]) => {
+export const usePreviousData = <M = unknown>(value: INode<M>[]) => {
   const ref = useRef<INode<M>[]>();
   useEffect(() => {
     ref.current = value;
@@ -45,7 +45,7 @@ export const usePreviousData = <M = IMetadata>(value: INode<M>[]) => {
   return ref.current;
 };
 
-export const isBranchNode = <M = IMetadata>(data: INode<M>[], i: NodeId) => {
+export const isBranchNode = <M = unknown>(data: INode<M>[], i: NodeId) => {
   const node = getTreeNode(data, i);
   return !!node.children?.length;
 };
@@ -62,11 +62,11 @@ export const focusRef = (ref: INodeRef) => {
   }
 };
 
-export const getParent = <M = IMetadata>(data: INode<M>[], id: NodeId) => {
+export const getParent = <M = unknown>(data: INode<M>[], id: NodeId) => {
   return getTreeNode(data, id).parent;
 };
 
-export const getAncestors = <M = IMetadata>(
+export const getAncestors = <M = unknown>(
   data: INode<M>[],
   childId: NodeId,
   disabledIds: Set<NodeId>
@@ -89,7 +89,7 @@ export const getAncestors = <M = IMetadata>(
   return ancestors;
 };
 
-export const getDescendants = <M = IMetadata>(
+export const getDescendants = <M = unknown>(
   data: INode<M>[],
   id: NodeId,
   disabledIds: Set<NodeId>
@@ -107,13 +107,13 @@ export const getDescendants = <M = IMetadata>(
   return descendants;
 };
 
-export const getChildren = <M = IMetadata>(data: INode<M>[], id: NodeId) => {
+export const getChildren = <M = unknown>(data: INode<M>[], id: NodeId) => {
   const children: NodeId[] = [];
   const node = getTreeNode(data, id);
   return node.children == null ? children : node.children;
 };
 
-export const getSibling = <M = IMetadata>(
+export const getSibling = <M = unknown>(
   data: INode<M>[],
   id: NodeId,
   diff: number
@@ -130,7 +130,7 @@ export const getSibling = <M = IMetadata>(
   return null;
 };
 
-export const getLastAccessible = <M = IMetadata>(
+export const getLastAccessible = <M = unknown>(
   data: INode<M>[],
   id: NodeId,
   expandedIds: Set<NodeId>
@@ -149,7 +149,7 @@ export const getLastAccessible = <M = IMetadata>(
   return node.id;
 };
 
-export const getPreviousAccessible = <M = IMetadata>(
+export const getPreviousAccessible = <M = unknown>(
   data: INode<M>[],
   id: NodeId,
   expandedIds: Set<NodeId>
@@ -164,7 +164,7 @@ export const getPreviousAccessible = <M = IMetadata>(
   return getLastAccessible(data, previous, expandedIds);
 };
 
-export const getNextAccessible = <M = IMetadata>(
+export const getNextAccessible = <M = unknown>(
   data: INode<M>[],
   id: NodeId,
   expandedIds: Set<NodeId>
@@ -187,7 +187,7 @@ export const getNextAccessible = <M = IMetadata>(
   }
 };
 
-export const propagateSelectChange = <M = IMetadata>(
+export const propagateSelectChange = <M = unknown>(
   data: INode<M>[],
   ids: Set<NodeId>,
   selectedIds: Set<NodeId>,
@@ -253,7 +253,7 @@ export const propagateSelectChange = <M = IMetadata>(
   return changes;
 };
 
-export const getAccessibleRange = <M = IMetadata>({
+export const getAccessibleRange = <M = unknown>({
   data,
   expandedIds,
   from,
@@ -288,14 +288,14 @@ export const getAccessibleRange = <M = IMetadata>({
   return range;
 };
 
-interface ITreeNode<M = IMetadata> {
+interface ITreeNode<M = unknown> {
   id?: NodeId;
   name: string;
   children?: ITreeNode<M>[];
   metadata?: M;
 }
 
-export const flattenTree = <M = IMetadata>(tree: ITreeNode<M>): INode<M>[] => {
+export const flattenTree = <M = unknown>(tree: ITreeNode<M>): INode<M>[] => {
   let internalCount = 0;
   const flattenedTree: INode<M>[] = [];
 
@@ -362,7 +362,7 @@ export const getAriaChecked = ({
   return isSelected ? true : undefined;
 };
 
-export const propagatedIds = <M = IMetadata>(
+export const propagatedIds = <M = unknown>(
   data: INode<M>[],
   ids: NodeId[],
   disabledIds: Set<NodeId>
@@ -394,7 +394,7 @@ export const onComponentBlur = (
   }
 };
 
-export const isBranchSelectedAndHasSelectedDescendants = <M = IMetadata>(
+export const isBranchSelectedAndHasSelectedDescendants = <M = unknown>(
   data: INode<M>[],
   elementId: NodeId,
   selectedIds: Set<NodeId>
@@ -408,7 +408,7 @@ export const isBranchSelectedAndHasSelectedDescendants = <M = IMetadata>(
   );
 };
 
-export const isBranchNotSelectedAndHasAllSelectedDescendants = <M = IMetadata>(
+export const isBranchNotSelectedAndHasAllSelectedDescendants = <M = unknown>(
   data: INode<M>[],
   elementId: NodeId,
   selectedIds: Set<NodeId>
@@ -422,7 +422,7 @@ export const isBranchNotSelectedAndHasAllSelectedDescendants = <M = IMetadata>(
   );
 };
 
-export const isBranchNotSelectedAndHasOnlySelectedChild = <M = IMetadata>(
+export const isBranchNotSelectedAndHasOnlySelectedChild = <M = unknown>(
   data: INode<M>[],
   elementId: NodeId,
   selectedIds: Set<NodeId>
@@ -436,7 +436,7 @@ export const isBranchNotSelectedAndHasOnlySelectedChild = <M = IMetadata>(
   );
 };
 
-export const isBranchSelectedAndHasOnlySelectedChild = <M = IMetadata>(
+export const isBranchSelectedAndHasOnlySelectedChild = <M = unknown>(
   data: INode<M>[],
   elementId: NodeId,
   selectedIds: Set<NodeId>
@@ -450,7 +450,7 @@ export const isBranchSelectedAndHasOnlySelectedChild = <M = IMetadata>(
   );
 };
 
-export const getTreeParent = <M = IMetadata>(data: INode<M>[]): INode<M> => {
+export const getTreeParent = <M = unknown>(data: INode<M>[]): INode<M> => {
   const parentNode: INode<M> | undefined = data.find(
     (node) => node.parent === null
   );
@@ -462,7 +462,7 @@ export const getTreeParent = <M = IMetadata>(data: INode<M>[]): INode<M> => {
   return parentNode;
 };
 
-export const getTreeNode = <M = IMetadata>(
+export const getTreeNode = <M = unknown>(
   data: INode<M>[],
   id: NodeId
 ): INode<M> => {

--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -241,7 +241,7 @@ export const propagateSelectChange = <M = IMetadata>(
           changes.none.add(parent);
         }
       } else {
-        if (enabledChildren.every(x => selectedIds.has(x))) {
+        if (enabledChildren.every((x) => selectedIds.has(x))) {
           changes.every.add(parent);
         } else {
           changes.some.add(parent);
@@ -308,7 +308,7 @@ export const flattenTree = <M = IMetadata>(tree: ITreeNode<M>): INode<M>[] => {
       metadata: tree.metadata,
     };
 
-    if (flattenedTree.find(x => x.id === node.id)) {
+    if (flattenedTree.find((x) => x.id === node.id)) {
       throw Error(
         `Multiple TreeView nodes have the same ID (${node.id}). IDs must be unique.`
       );
@@ -466,7 +466,7 @@ export const getTreeNode = <M = IMetadata>(
   data: INode<M>[],
   id: NodeId
 ): INode<M> => {
-  const treeNode = data.find(node => node.id === id);
+  const treeNode = data.find((node) => node.id === id);
 
   if (treeNode == null) {
     throw Error(`Node with id=${id} doesn't exist in the tree.`);

--- a/src/__tests__/TreeViewMetadata.test.tsx
+++ b/src/__tests__/TreeViewMetadata.test.tsx
@@ -49,7 +49,7 @@ const initialTreeNode = {
 const mapDataType = flattenTree(initialTreeNode);
 
 interface TreeViewDataTypeProps {
-  data: INode[];
+  data: INode<{ color: string }>[];
 }
 
 function TreeViewMetadata(props: TreeViewDataTypeProps) {

--- a/src/__tests__/TreeViewMetadata.test.tsx
+++ b/src/__tests__/TreeViewMetadata.test.tsx
@@ -5,6 +5,10 @@ import { render } from "@testing-library/react";
 import { flattenTree } from "../TreeView/utils";
 import { INode } from "../TreeView/types";
 
+interface Metadata {
+  color: string;
+}
+
 const initialTreeNode = {
   name: "",
   id: 12,
@@ -46,10 +50,10 @@ const initialTreeNode = {
   ],
 };
 
-const mapDataType = flattenTree(initialTreeNode);
+const mapDataType = flattenTree<Metadata>(initialTreeNode);
 
 interface TreeViewDataTypeProps {
-  data: INode<{ color: string }>[];
+  data: INode<Metadata>[];
 }
 
 function TreeViewMetadata(props: TreeViewDataTypeProps) {

--- a/src/__tests__/TreeViewMetadata.test.tsx
+++ b/src/__tests__/TreeViewMetadata.test.tsx
@@ -50,7 +50,7 @@ const initialTreeNode = {
   ],
 };
 
-const mapDataType = flattenTree<Metadata>(initialTreeNode);
+const mapDataType = flattenTree(initialTreeNode);
 
 interface TreeViewDataTypeProps {
   data: INode<Metadata>[];

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -39,7 +39,7 @@ An array of nodes. Nodes are objects with the following structure:
 | `children` | `array[id]`          | required | An array with the ids of the children nodes.                                                              |
 | `parent`   | `id`                 | required | The parent of the node. `null` for the root node                                                          |
 | `isBranch` | `boolean`            | optional | Used to indicated whether a node is branch to be able load async data onExpand, default is false          |
-| `metadata` | `object`             | optional | Used to add metadata into node object. We do not currently support metadata that is a nested object       |
+| `metadata` | `any`                | optional | Used to add metadata into node object       |
 
 The item with `parent:null` of the array represents the root node and won't be displayed.
 


### PR DESCRIPTION
Resolves #129 

## What does this PR do?
In general, metadata is used to provide additional static properties that can be used to provide unique rendering or functionality to the given node. In many (similar) libraries, we can also use this metadata object to pass mutable data between rerenders. With this in mind, the current scope of the metadata object is too limited. Therefore, I propose that we do 2 things:

1. Do not clone metadata in the flattenTree function
2. Allow anything as metadata but default to `undefined`

### 1. Do not clone metadata
This change is rather simple compared to the rest of the changes and can easily get lost. Therefore I wanted to call it out here. In `flattenTree` we pass the node `metadata` directly to the new node rather than shallow cloning the `metadata` object.

<img width="1068" alt="Screenshot 2023-06-25 at 8 06 56 AM" src="https://github.com/dgreene1/react-accessible-treeview/assets/32177944/dfd3cd87-13e7-4dd5-b537-b8335c3ea7bc">

### 2. Allow anything as metadata
Technically, from a javascript perspective, there is nothing preventing a user from anything they want to `metadata`. It is only in typescript that we restrict the type of the `metadata` object to a non-nested object. The only time (the library) interacts with `metadata` is to propagate it in `flattenTree`. Otherwise, the library has no other direct references to it. Therefore, the bulk of these changes serve to adjust how the type of `metadata` is propagated throughout the tree. 

1. The `IFlatMetadata` type has been renamed to `IMetadata`
2. Since the the metadata is fully controlled/operated on by the user, we don't care how the user wants to use their `metadata` or what shape its in. Therefore, we set `IMetadata` to `undefined` by default and allow the user to pass in the type of their metadata as a generic.
3. Expose the generic to the user in the component or types that they will most likely interact with. This includes `TreeView` `flattenTree` `INode` and `INodeRendererProps`.

#### Examples
For example, the user can pass the type of their `metadata` to the `TreeView` component itself. 
```ts
interface MyMetadata {
  color: string;
}

<TreeView<MyMetadata>
  data={data}
  nodeRenderer={({ element, getNodeProps }) => (
    // `element.metadata.color` will be correctly typed as a `string` inside this function
    <div {...getNodeProps}>{element.metadata.color}</div>
  )}
/>
```

Alternatively, we can pre-define the type of the `data` that is passed to the tree using the `metadata` generic, which will then propagate the type throughout the component.
```ts
interface MyMetadata {
  color: string;
}

const data: INode<MyMetadata>[] = [ ... ];
// or
const data = flattenTree<MyMetadata({ ... })

<TreeView
  data={data}
  nodeRenderer={({ element, getNodeProps }) => (
    // `element.metadata.color` will be correctly typed as a `string` inside this function
    <div {...getNodeProps}>{element.metadata.color}</div>
  )}
/>
```

The end result is that the type of the user defined metadata is available to the use in the `nodeRenderer` function. This example is take from `TreeViewMetadata.test.tsx`.

<img width="532" alt="Screenshot 2023-06-25 at 1 49 15 AM" src="https://github.com/dgreene1/react-accessible-treeview/assets/32177944/4cddbc91-8fb3-4c66-8552-a046d416e100">

For context, the type of `color` in master is `string | number | null | undefined`.

#### List of changed types and functions
In order for the above examples to work, the type of `metadata` needs to be propagated through every type and function that directly or indirectly references the `INode` type. Each of these must be updated to support the `metadata` generic to allow it to pass through the type of the `metadata`. This affects the following types and functions:
```ts
// Types
ITreeViewProps
ITreeViewOnLoadDataProps
ITreeViewOnExpandProps
ITreeViewOnNodeSelectProps
ITreeViewOnSelectProps
INodeRendererProps
INodeProps
INodeGroupProps

// Functions
useTree
usePreviousData
handleKeydown
isBranchNode
getParent
getAncestors
getDescendants
getChildren
getSibling
getLastAccessible
getPreviousAccessible
getNextAccessible
propagateSelectChange
getAccessibleRange
propagatedIds
isBranchSelectedAndHasSelectedDescendants
isBranchNotSelectedAndHasAllSelectedDescendants
isBranchNotSelectedAndHasOnlySelectedChild
isBranchSelectedAndHasOnlySelectedChild
getTreeParent
getTreeNode
validateTreeViewData

// Components
Node
NodeGroup
TreeView
```

## For reviewers
My IDE auto-formatted the files. I tried to revert as many of the formatting changes as I could find but may have missed some. So if you are thinking... "Why did he add that comma", the auto-formatter is probably why.
