### PR TITLE
Fix a bug with node deletion

### DIFF
--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -260,7 +260,7 @@ const useTree = ({
       toggleControlledExpandedIds
     );
     //controlled collapsing
-    if (diffCollapseIds.size) {
+    /*if (diffCollapseIds.size) {
       for (const id of diffCollapseIds) {
         if (isBranchNode(data, id) || getTreeNode(data, id).isBranch) {
           const ids = [id, ...getDescendants(data, id, new Set<number>())];
@@ -271,7 +271,7 @@ const useTree = ({
           });
         }
       }
-    }
+    }*/
     //controlled expanding
     if (diffExpandedIds.size) {
       for (const id of diffExpandedIds) {

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -255,23 +255,26 @@ const useTree = ({
       prevExpandedIds
     );
     //nodes to be collapsed
-    /*const diffCollapseIds = difference(
+    const diffCollapseIds = difference(
       prevExpandedIds,
       toggleControlledExpandedIds
     );
     //controlled collapsing
     if (diffCollapseIds.size) {
       for (const id of diffCollapseIds) {
-        if (isBranchNode(data, id) || getTreeNode(data, id).isBranch) {
-          const ids = [id, ...getDescendants(data, id, new Set<number>())];
-          dispatch({
-            type: treeTypes.collapseMany,
-            ids: ids,
-            lastInteractedWith: id,
-          });
+        const index = data.findIndex(x => x.id === id);
+        if(index !== -1){
+          if (isBranchNode(data, id) || getTreeNode(data, id).isBranch) {
+            const ids = [id, ...getDescendants(data, id, new Set<number>())];
+            dispatch({
+              type: treeTypes.collapseMany,
+              ids: ids,
+              lastInteractedWith: id,
+            });
+          }
         }
       }
-    }*/
+    }
     //controlled expanding
     if (diffExpandedIds.size) {
       for (const id of diffExpandedIds) {

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -255,12 +255,12 @@ const useTree = ({
       prevExpandedIds
     );
     //nodes to be collapsed
-    const diffCollapseIds = difference(
+    /*const diffCollapseIds = difference(
       prevExpandedIds,
       toggleControlledExpandedIds
     );
     //controlled collapsing
-    /*if (diffCollapseIds.size) {
+    if (diffCollapseIds.size) {
       for (const id of diffCollapseIds) {
         if (isBranchNode(data, id) || getTreeNode(data, id).isBranch) {
           const ids = [id, ...getDescendants(data, id, new Set<number>())];


### PR DESCRIPTION
### What does this PR do?
It fixes a bug with node deletion. The bug happens when you send data with some nodes missing (because you deleted them) to _TreeView_ component, and you want to have all nodes expanded with _expandedId_ prop. This small fix just checks if node is still in the tree before trying to collapse it, otherwise the exception "Node with id=x doesn't exist in the tree" will be thrown.
