### PR TITLE
Fix preserving half-selected parent node after setting selectedIds to empty array.

### DIFF
--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -242,6 +242,7 @@ const useTree = ({
             ids: propagatedIds(data, [id], disabledIds),
             select: true,
             multiSelect,
+            lastInteractedWith: id
           });
       }
     }

--- a/src/TreeView/reducer.ts
+++ b/src/TreeView/reducer.ts
@@ -323,8 +323,8 @@ export const treeReducer = (
       if (action.multiSelect) {
         selectedIds = new Set<NodeId>(action.ids);
         if (action.ids.length) {
-          lastInteractedWith = tabbableId =
-            action.ids[action.ids.length - 1];
+          lastInteractedWith = action.ids[action.ids.length - 1];
+          tabbableId = action.ids[action.ids.length - 1];
         }
       } else {
         selectedIds = new Set<NodeId>();
@@ -335,8 +335,8 @@ export const treeReducer = (
         }
         const idToAdd = action.ids[0];
         idToAdd && selectedIds.add(idToAdd);
-        lastInteractedWith = tabbableId =
-          idToAdd ?? lastInteractedWith;
+        lastInteractedWith = idToAdd ?? lastInteractedWith;
+        tabbableId = idToAdd ?? lastInteractedWith;
       }
 
       const halfSelectedIds = new Set<NodeId>(state.halfSelectedIds);

--- a/src/TreeView/reducer.ts
+++ b/src/TreeView/reducer.ts
@@ -312,8 +312,14 @@ export const treeReducer = (
     }
     case treeTypes.controlledSelectMany: {
       let selectedIds;
+      let lastInteractedWith = state.lastInteractedWith;
+      let tabbableId = state.tabbableId;
       if (action.multiSelect) {
         selectedIds = new Set<NodeId>(action.ids);
+        if (action.ids.length) {
+          lastInteractedWith = tabbableId =
+            action.ids[action.ids.length - 1];
+        }
       } else {
         selectedIds = new Set<NodeId>();
         if (action.ids.length > 1) {
@@ -323,6 +329,8 @@ export const treeReducer = (
         }
         const idToAdd = action.ids[0];
         idToAdd && selectedIds.add(idToAdd);
+        lastInteractedWith = tabbableId =
+          idToAdd ?? lastInteractedWith;
       }
 
       const halfSelectedIds = new Set<NodeId>(state.halfSelectedIds);
@@ -336,6 +344,8 @@ export const treeReducer = (
         controlledIds,
         isFocused: true,
         lastAction: action.type,
+        tabbableId,
+        lastInteractedWith,
       };
     }
     case treeTypes.focus:

--- a/src/__tests__/ControlledTree.test.tsx
+++ b/src/__tests__/ControlledTree.test.tsx
@@ -301,6 +301,49 @@ describe("Data without ids", () => {
     expect(newNodes[4]).toHaveAttribute("aria-checked", "false");
     expect(newNodes[5]).toHaveAttribute("aria-checked", "false");
   });
+
+  test("SelectedIds should propagate upward when deselection happens via selectedIds", () => {
+    const data = flattenTree({
+      name: "",
+      children: [
+        {
+          name: "Drinks",
+          children: [
+            {
+              name: "Coffee",
+              children: [
+                {
+                  name: "Arabica",
+                  children: [
+                    { name: "Black", children: [{ name: "Espresso" }] },
+                  ],
+                },
+                { name: "Robusta" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const getNodes = () => container.querySelectorAll('[role="treeitem"]');
+
+    const { rerender, container } = render(
+      <MultiSelectCheckboxControlled selectedIds={[1]} data={data} defaultExpandedIds={[1,2,3]} />
+    );
+
+    getNodes().forEach(node => {
+      expect(node).toHaveAttribute("aria-checked", "true");
+    });
+
+    rerender(<MultiSelectCheckboxControlled selectedIds={[6]} data={data} defaultExpandedIds={[1,2,3]} />);
+    expect(getNodes()[0]).toHaveAttribute("aria-checked", "mixed");
+    expect(getNodes()[1]).toHaveAttribute("aria-checked", "mixed");
+    expect(getNodes()[4]).toHaveAttribute("aria-checked", "true");
+
+    rerender(<MultiSelectCheckboxControlled selectedIds={[]} data={data} defaultExpandedIds={[1,2,3]} />);
+    expect(getNodes()[0]).toHaveAttribute("aria-checked", "false");
+    expect(getNodes()[1]).toHaveAttribute("aria-checked", "false");
+  });
 });
 
 describe("Data with ids", () => {


### PR DESCRIPTION
Fix preserving half-selected parent node after setting selectedIds to empty array.

Without fix:
https://github.com/dgreene1/react-accessible-treeview/assets/16884481/66b4ecc8-4864-4654-805e-aa5846736726


With fix:
https://github.com/dgreene1/react-accessible-treeview/assets/16884481/cbe63802-9403-443c-886c-02d31ce7b226


Ref: UIEN-4274