### PR TITLE
Fix issue with adding focus classes on a tree without any interaction.

### DIFF
--- a/src/TreeView/reducer.ts
+++ b/src/TreeView/reducer.ts
@@ -215,7 +215,7 @@ export const treeReducer = (
         selectedIds,
         halfSelectedIds,
         tabbableId: action.keepFocus ? state.tabbableId : action.id,
-        isFocused: true,
+        isFocused: action.NotUserAction !== true,
         lastUserSelect: action.NotUserAction ? state.lastUserSelect : action.id,
         lastAction: action.type,
         lastInteractedWith: action.lastInteractedWith,


### PR DESCRIPTION
When on initial tree loading propagation automatically selects any parent node, first node in a tree gets --focused style, thus if consumers use this styles in addition to :visual-focus pseudo-class this causes a confusion that visually there is a focused tree element on a page without any interaction.

Ref: UIEN-4502