### PR TITLE
Prevent tree from stealing focus from the page (for Issue #142)

### DIFF
--- a/src/__tests__/ControlledTree.test.tsx
+++ b/src/__tests__/ControlledTree.test.tsx
@@ -753,4 +753,22 @@ describe("Data with ids", () => {
     expect(newNodes[4]).toHaveAttribute("aria-checked", "false");
     expect(newNodes[5]).toHaveAttribute("aria-checked", "false");
   });
+  
+  test("SelectedIds should be not steal focus if another control has it", () => {
+    let selectedIds = [42];
+    let renderContent = (<div>
+      <input type="text" id="editor"/>
+      <MultiSelectCheckboxControlled
+        selectedIds={selectedIds}
+        data={dataWithIds}
+      />
+      </div>);
+    const { rerender } = render(renderContent);
+
+    const editorElement = document?.getElementById("editor");
+    editorElement?.focus();
+    selectedIds = [4];
+    rerender(renderContent);
+    expect(document.activeElement).toEqual(editorElement);
+  });
 });

--- a/src/__tests__/ControlledTree.test.tsx
+++ b/src/__tests__/ControlledTree.test.tsx
@@ -754,7 +754,7 @@ describe("Data with ids", () => {
     expect(newNodes[5]).toHaveAttribute("aria-checked", "false");
   });
   
-  test("SelectedIds should be not steal focus if another control has it", () => {
+  test("SelectedIds should not steal focus if another control has it", () => {
     let selectedIds = [42];
     let renderContent = (<div>
       <input type="text" id="editor"/>

--- a/src/__tests__/ControlledTree.test.tsx
+++ b/src/__tests__/ControlledTree.test.tsx
@@ -756,7 +756,7 @@ describe("Data with ids", () => {
   
   test("SelectedIds should not steal focus if another control has it", () => {
     let selectedIds = [42];
-    let renderContent = (<div>
+    const renderContent = (<div>
       <input type="text" id="editor"/>
       <MultiSelectCheckboxControlled
         selectedIds={selectedIds}


### PR DESCRIPTION
- If the user is not interacting directly with the tree already, it should not be able to scroll itself into view or take over focus when it is being controlled by something else on the page.
- In situations like a master + details view where the tree is the details and the master control changes what is selected in the tree, the tree should not steal focus from the other control whose actions were modifying it. Such as if a user is arrowing through a list at the top of the page and there is a tree below it.

Related issue:
https://github.com/dgreene1/react-accessible-treeview/issues/142
