### PR TITLE
Add boolean support. Fixes #164

### DIFF
--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -290,7 +290,7 @@ export const getAccessibleRange = ({
 /**
  * This is to help consumers to understand that we do not currently support metadata that is a nested object. If this is needed, make an issue in Github
  */
-export type IFlatMetadata = Record<string, string | number | undefined | null>;
+export type IFlatMetadata = Record<string, string | number | boolean | undefined | null>;
 
 interface ITreeNode<M extends IFlatMetadata> {
   id?: NodeId;

--- a/src/__tests__/TreeViewMetadata.test.tsx
+++ b/src/__tests__/TreeViewMetadata.test.tsx
@@ -13,27 +13,27 @@ const initialTreeNode = {
       name: "Fruits",
       id: 54,
       children: [
-        { name: "Avocados", id: 98, metadata: { color: 'green' } },
-        { name: "Bananas", id: 789, metadata: { color: 'yellow' } },
+        { name: "Avocados", id: 98, metadata: { color: 'green', available: true } },
+        { name: "Bananas", id: 789, metadata: { color: 'yellow', available: false } },
       ],
     },
     {
       id: 888,
       name: "Drinks",
       children: [
-        { name: "Apple Juice", id: 990, metadata: { color: 'yellow' } },
-        { name: "Coffee", id: 9 , metadata: { color: 'brown' }},
+        { name: "Apple Juice", id: 990, metadata: { color: 'yellow', available: true } },
+        { name: "Coffee", id: 9 , metadata: { color: 'brown', available: true }},
         {
           id: 43,
           name: "Tea",
           children: [
-            { name: "Black Tea", id: 4,  metadata: { color: 'black' } },
-            { name: "Green Tea", id: 44, metadata: { color: 'green' } },
+            { name: "Black Tea", id: 4,  metadata: { color: 'black', available: false } },
+            { name: "Green Tea", id: 44, metadata: { color: 'green', available: false } },
             {
               id: 53,
               name: "Matcha",
-              metadata: { color: 'green' },
-              children: [{ name: "Matcha 1", id: 2, metadata: { color: 'green' } }],
+              metadata: { color: 'green', available: true },
+              children: [{ name: "Matcha 1", id: 2, metadata: { color: 'green', available: false } }],
             },
           ],
         },
@@ -101,7 +101,7 @@ function TreeViewMetadata(props: TreeViewDataTypeProps) {
       const thisNodesMetadata = nodeData.metadata;
       if (thisNodesMetadata !== undefined) {
         const node = nodes.find((x) => {
-          return x.innerHTML.includes(`${thisNodesMetadata.color}`)
+          return x.innerHTML.includes(`${thisNodesMetadata.color}`) && x.innerHTML.includes(`${thisNodesMetadata.available}`)
         });
         expect(node).toBeDefined;
      } else {


### PR DESCRIPTION
This adds support for booleans in the node metadata. This change will make it easier for a use-case we have at Shopify. Initially I ran prettier on the project, but noticed that the `lint-staged` config seems to be broken, because both files had *lots* of changes after running prettier. If you'd like, I can add a separate commit to auto format the code.

closes #164