### PR TITLE
Do not error when data has nodes removed that are expanded

### DIFF
--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -294,33 +294,37 @@ const useTree = ({
     //controlled collapsing
     if (diffCollapseIds.size) {
       for (const id of diffCollapseIds) {
-        if (isBranchNode(data, id) || getTreeNode(data, id).isBranch) {
-          const ids = [id, ...getDescendants(data, id, new Set<number>())];
-          dispatch({
-            type: treeTypes.collapseMany,
-            ids: ids,
-            lastInteractedWith: id,
-          });
+        if (data.find((n) => n.id === id)) {
+          if (isBranchNode(data, id) || getTreeNode(data, id).isBranch) {
+            const ids = [id, ...getDescendants(data, id, new Set<number>())];
+            dispatch({
+              type: treeTypes.collapseMany,
+              ids: ids,
+              lastInteractedWith: id,
+            });
+          }
         }
       }
     }
     //controlled expanding
     if (diffExpandedIds.size) {
       for (const id of diffExpandedIds) {
-        if (isBranchNode(data, id) || getTreeNode(data, id).isBranch) {
-          const parentId = getParent(data, id);
-          if (parentId) {
-            dispatch({
-              type: treeTypes.expandMany,
-              ids: [id, parentId],
-              lastInteractedWith: id,
-            });
-          } else {
-            dispatch({
-              type: treeTypes.expand,
-              id: id,
-              lastInteractedWith: id,
-            });
+        if (data.find((n) => n.id === id)) {
+          if (isBranchNode(data, id) || getTreeNode(data, id).isBranch) {
+            const parentId = getParent(data, id);
+            if (parentId) {
+              dispatch({
+                type: treeTypes.expandMany,
+                ids: [id, parentId],
+                lastInteractedWith: id,
+              });
+            } else {
+              dispatch({
+                type: treeTypes.expand,
+                id: id,
+                lastInteractedWith: id,
+              });
+            }
           }
         }
       }

--- a/src/__tests__/ControlledExpandedNode.test.tsx
+++ b/src/__tests__/ControlledExpandedNode.test.tsx
@@ -206,6 +206,37 @@ describe("Without node ids", () => {
     expect(nodesAfterExpandedAll[6]).toHaveAttribute("aria-expanded", "true");
     expect(nodesAfterExpandedAll[11]).toHaveAttribute("aria-expanded", "true");
   });
+  test("Should rerender when the data and expanded nodes change", () => {
+    const expandedIds = [1, 7, 11];
+
+    const { queryAllByRole, rerender } = render(
+      <ControlledExpanded expandedIds={expandedIds} data={dataWithoutIds} />
+    );
+
+    let nodes = queryAllByRole("treeitem");
+    expect(nodes.length).toBe(16);
+
+    // remove the fruits directory from both data and expandedIds
+    rerender(
+      <ControlledExpanded
+        expandedIds={[7, 11]}
+        data={dataWithoutIds
+          .filter((node) => node.id !== 1)
+          .map((node) => ({
+            ...node,
+            children: node.children.filter((child) => child !== 1),
+          }))}
+      />
+    );
+
+    nodes = queryAllByRole("treeitem");
+    // six nodes were removed (everything in fruits)
+    expect(nodes.length).toBe(10);
+
+    expect(nodes[0]).toHaveAttribute("aria-expanded", "true");
+    expect(nodes[1]).not.toHaveAttribute("aria-expanded");
+    expect(nodes[4]).toHaveAttribute("aria-expanded", "true");
+  });
 });
 
 describe("With node ids", () => {


### PR DESCRIPTION
We use `react-accessible-treeview` at Shopify along with folder/file search. With our implementation the rendered nodes change based on the search query. We also want the nodes to default to being expanded. As shown with the included test, `TreeView` breaks when re-rendered where both the `data` and `expandedIds` props change.

The problem is that the _previous_ expandedIds data is stored, and the [difference is calculated](https://github.com/dgreene1/react-accessible-treeview/blob/master/src/TreeView/index.tsx#L110). But an ID should not be included in the difference if that ID doesn't still exist in the data. As I see it, there are two solutions:

1. If the id is not found in the data, ignore it. That's what's implemented in this PR, inspired by https://github.com/dgreene1/react-accessible-treeview/pull/132
2. Change the difference function to take the tree data as a param, and only add an ID to the diff if it's still in the data tree.

This resolves #133

I think I have a workaround by _never_ removing nodes from the tree, and instead adding a boolean to the metadata whether or not it should be displayed.

