### PR TITLE
:sparkles: Feat: add `allowKeyboardControl` prop to TreeView component

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A react component that implements the treeview pattern as described by the [WAI-
 | `expandedIds`            | `array`       | `[]`          | (Controlled) Array with the ids of branch node that should be expanded                                                                                                    |
 | `clickAction`            | `enum`        | `SELECT`      | Action to perform on click. One of: EXCLUSIVE_SELECT, FOCUS, SELECT                                                                                                       |
 | `onBlur`                 | `func`        | `noop`        | Custom onBlur event that is triggered when focusing out of the component as a whole (moving focus between the nodes won't trigger it).                                    |
+| `allowKeyboardControl`   | `bool`        | `true`        | If set to false, the tree will not respond to keyboard events.                                                                                                            |
 
 <br/> <br/>
 

--- a/src/TreeView/README.md
+++ b/src/TreeView/README.md
@@ -30,6 +30,7 @@ A react component that implements the treeview pattern as described by the [WAI-
 | `selectedIds`            | `array`       | `[]`          | (Controlled) Array with the ids that should be selected                                                                                                                   |
 | `expandedIds`            | `array`       | `[]`          | (Controlled) Array with the ids of branch node that should be expanded                                                                                                    |
 | `clickAction`            | `enum`        | `SELECT`      | Action to perform on click. One of: EXCLUSIVE_SELECT, FOCUS, SELECT                                                                                                       |
+| `allowKeyboardControl`   | `bool`        | `true`        | If set to false, the tree will not respond to keyboard events.                                                                                                            |
 
 <br/> <br/>
 

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -551,11 +551,14 @@ export interface ITreeViewProps {
   }) => void;
   /** Id of the node to focus */
   focusedId?: NodeId;
+  /** Allows enabling or disabling all keyboard interactions. When disabled, no keyboard events will be handled by the component. */
+  allowKeyboardControl?: boolean;
 }
 
 const TreeView = React.forwardRef<HTMLUListElement, ITreeViewProps>(
   function TreeView(
     {
+      allowKeyboardControl = true,
       data,
       selectedIds,
       nodeRenderer,
@@ -628,6 +631,7 @@ const TreeView = React.forwardRef<HTMLUListElement, ITreeViewProps>(
           });
         }}
         onKeyDown={handleKeyDown({
+          allowKeyboardControl,
           data,
           tabbableId: state.tabbableId,
           expandedIds: state.expandedIds,
@@ -674,6 +678,7 @@ const TreeView = React.forwardRef<HTMLUListElement, ITreeViewProps>(
 );
 
 const handleKeyDown = ({
+  allowKeyboardControl = true,
   data,
   expandedIds,
   selectedIds,
@@ -687,6 +692,7 @@ const handleKeyDown = ({
   togglableSelect,
   clickAction,
 }: {
+  allowKeyboardControl?: boolean;
   data: INode[];
   tabbableId: NodeId;
   expandedIds: Set<NodeId>;
@@ -701,6 +707,8 @@ const handleKeyDown = ({
   togglableSelect?: boolean;
   clickAction: ClickActions;
 }) => (event: React.KeyboardEvent) => {
+  if (!allowKeyboardControl) return;
+
   const element = getTreeNode(data, tabbableId);
   const id = element.id;
   if (event.ctrlKey) {


### PR DESCRIPTION
### Description of Changes

#### Added `allowKeyboardControl` Property

**Summary:**
Introduced a new optional boolean property `allowKeyboardControl` to the TreeView component. This property allows developers to enable or disable all keyboard interactions within the TreeView. By default, this property is set to `true`, allowing keyboard interactions.

**Changes in Detail:**
1. **Interface Changes:**
   - Modified `ITreeViewProps` interface in `src/TreeView/index.tsx` to include `allowKeyboardControl` with a default value of `true`.

2. **Component Logic Updates:**
   - Integrated the `allowKeyboardControl` property into the `TreeView` component's props.
   - Updated the `handleKeyDown` function to respect the `allowKeyboardControl` property. If `allowKeyboardControl` is set to `false`, the function will return immediately, preventing any keyboard events from being handled.

**Benefits:**
This change enhances the flexibility of the TreeView component, allowing developers to disable keyboard interactions when necessary, providing better control over the component's behavior in different use cases.