### PR TITLE
fix for broken inference on metadata prop

### DIFF
--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -672,14 +672,11 @@ function TreeViewInner<M extends IFlatMetadata>(
     )
   }
 
-  function genericForwardRef<T, P = Record<string, unknown>>(
-    render: (props: P, ref: React.Ref<T>) => JSX.Element
-  ): (props: P & React.RefAttributes<T>) => JSX.Element {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return React.forwardRef(render) as any;
-  }
 
-const TreeView = genericForwardRef(TreeViewInner)
+  const TreeView = React.forwardRef(TreeViewInner) as <T extends IFlatMetadata>(
+    props: ITreeViewProps<T> & React.RefAttributes<T>
+  ) => ReturnType<typeof TreeViewInner>;
+
 
 
 const handleKeyDown = ({
@@ -984,7 +981,8 @@ const handleKeyDown = ({
   }
 };
 
-TreeViewInner.propTypes = {
+//@ts-expect-error
+TreeView.propTypes = {
   /** Tree data*/
   data: PropTypes.array.isRequired,
 

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -503,7 +503,7 @@ export interface ITreeViewOnLoadDataProps {
   treeState: ITreeViewState;
 }
 
-export interface ITreeViewProps<M extends IFlatMetadata> {
+export interface ITreeViewProps<M extends IFlatMetadata = IFlatMetadata> {
   /** Tree data*/
   data: INode<M>[];
   /** Function called when a node changes its selected state */
@@ -648,7 +648,7 @@ function TreeViewInner<M extends IFlatMetadata>(
           <Node
             key={`${x}-${typeof x}`}
             data={data}
-            element={getTreeNode(data, x)}
+            element={getTreeNode(data, x) as INode<M>}
             setsize={getTreeParent(data).children.length}
             posinset={index + 1}
             level={1}
@@ -981,7 +981,7 @@ const handleKeyDown = ({
   }
 };
 
-//@ts-expect-error
+//@ts-expect-error type assertion for ts
 TreeView.propTypes = {
   /** Tree data*/
   data: PropTypes.array.isRequired,

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -554,7 +554,8 @@ export interface ITreeViewProps<M extends IFlatMetadata = IFlatMetadata> {
   focusedId?: NodeId;
 }
 
-function TreeViewInner<M extends IFlatMetadata>(
+const TreeView = React.forwardRef(
+function TreeView<M extends IFlatMetadata = IFlatMetadata>(
     {
       data,
       selectedIds,
@@ -670,12 +671,9 @@ function TreeViewInner<M extends IFlatMetadata>(
         ))}
       </ul>
     )
-  }
+  })
 
 
-  const TreeView = React.forwardRef(TreeViewInner) as <T extends IFlatMetadata>(
-    props: ITreeViewProps<T> & React.RefAttributes<T>
-  ) => ReturnType<typeof TreeViewInner>;
 
 
 
@@ -981,7 +979,7 @@ const handleKeyDown = ({
   }
 };
 
-//@ts-expect-error type assertion for ts
+
 TreeView.propTypes = {
   /** Tree data*/
   data: PropTypes.array.isRequired,

--- a/src/TreeView/node.tsx
+++ b/src/TreeView/node.tsx
@@ -26,7 +26,7 @@ import {
 } from "./utils";
 import { baseClassNames, clickActions, treeTypes } from "./constants";
 
-export interface INodeProps<M extends IFlatMetadata> {
+export interface INodeProps<M extends IFlatMetadata = IFlatMetadata> {
   element: INode<M>;
   dispatch: React.Dispatch<TreeViewAction>;
   data: INode<M>[];
@@ -54,7 +54,7 @@ export interface INodeProps<M extends IFlatMetadata> {
   propagateSelectUpwards: boolean;
 }
 
-export interface INodeGroupProps<M extends IFlatMetadata>
+export interface INodeGroupProps<M extends IFlatMetadata = IFlatMetadata>
   extends Omit<INodeProps<M>, "setsize" | "posinset"> {
   getClasses: (className: string) => string;
   /** don't send this. The NodeGroup render function, determines it for you */
@@ -66,7 +66,7 @@ export interface INodeGroupProps<M extends IFlatMetadata>
 /**
  * It's convenient to pass props down to the child, but we don't want to pass everything since it would create incorrect values for setsize and posinset
  */
-const removeIrrelevantGroupProps = <M extends IFlatMetadata,>(
+const removeIrrelevantGroupProps = <M extends IFlatMetadata = IFlatMetadata,>(
   nodeProps: INodeProps<M>
 ): Omit<INodeGroupProps<M>, "getClasses"> => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -74,7 +74,7 @@ const removeIrrelevantGroupProps = <M extends IFlatMetadata,>(
   return rest;
 };
 
-export const Node = <M extends IFlatMetadata>(props: INodeProps<M>) => {
+export const Node = <M extends IFlatMetadata = IFlatMetadata>(props: INodeProps<M>) => {
   const {
     element,
     dispatch,
@@ -330,7 +330,7 @@ export const NodeGroup = <M extends IFlatMetadata = IFlatMetadata>({
           expandedIds={expandedIds}
           baseClassNames={baseClassNames}
           key={`${x}-${typeof x}`}
-          element={getTreeNode(data, x) as INode<M>}
+          element={getTreeNode(data, x)}
           setsize={element.children.length}
           posinset={index + 1}
           level={level + 1}

--- a/src/TreeView/node.tsx
+++ b/src/TreeView/node.tsx
@@ -22,13 +22,14 @@ import {
   noop,
   propagatedIds,
   getOnSelectTreeAction,
+  IFlatMetadata,
 } from "./utils";
 import { baseClassNames, clickActions, treeTypes } from "./constants";
 
-export interface INodeProps {
-  element: INode;
+export interface INodeProps<M extends IFlatMetadata> {
+  element: INode<M>;
   dispatch: React.Dispatch<TreeViewAction>;
-  data: INode[];
+  data: INode<M>[];
   nodeAction: NodeAction;
   selectedIds: Set<NodeId>;
   tabbableId: NodeId;
@@ -40,7 +41,7 @@ export interface INodeProps {
   nodeRefs: INodeRefs;
   leafRefs: INodeRefs;
   baseClassNames: typeof baseClassNames;
-  nodeRenderer: (props: INodeRendererProps) => React.ReactNode;
+  nodeRenderer: (props: INodeRendererProps<M>) => React.ReactNode;
   setsize: number;
   posinset: number;
   level: number;
@@ -53,8 +54,8 @@ export interface INodeProps {
   propagateSelectUpwards: boolean;
 }
 
-export interface INodeGroupProps
-  extends Omit<INodeProps, "setsize" | "posinset"> {
+export interface INodeGroupProps<M extends IFlatMetadata>
+  extends Omit<INodeProps<M>, "setsize" | "posinset"> {
   getClasses: (className: string) => string;
   /** don't send this. The NodeGroup render function, determines it for you */
   setsize?: undefined;
@@ -65,15 +66,15 @@ export interface INodeGroupProps
 /**
  * It's convenient to pass props down to the child, but we don't want to pass everything since it would create incorrect values for setsize and posinset
  */
-const removeIrrelevantGroupProps = (
-  nodeProps: INodeProps
-): Omit<INodeGroupProps, "getClasses"> => {
+const removeIrrelevantGroupProps = <M extends IFlatMetadata,>(
+  nodeProps: INodeProps<M>
+): Omit<INodeGroupProps<M>, "getClasses"> => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { setsize, posinset, ...rest } = nodeProps;
   return rest;
 };
 
-export const Node = (props: INodeProps) => {
+export const Node = <M extends IFlatMetadata>(props: INodeProps<M>) => {
   const {
     element,
     dispatch,
@@ -311,7 +312,7 @@ export const Node = (props: INodeProps) => {
   );
 };
 
-export const NodeGroup = ({
+export const NodeGroup = <M extends IFlatMetadata = IFlatMetadata>({
   data,
   element,
   expandedIds,
@@ -319,7 +320,7 @@ export const NodeGroup = ({
   baseClassNames,
   level,
   ...rest
-}: INodeGroupProps) => (
+}: INodeGroupProps<M>) => (
   <ul role="group" className={getClasses(baseClassNames.nodeGroup)}>
     {expandedIds.has(element.id) &&
       element.children.length > 0 &&
@@ -329,7 +330,7 @@ export const NodeGroup = ({
           expandedIds={expandedIds}
           baseClassNames={baseClassNames}
           key={`${x}-${typeof x}`}
-          element={getTreeNode(data, x)}
+          element={getTreeNode(data, x) as INode<M>}
           setsize={element.children.length}
           posinset={index + 1}
           level={level + 1}

--- a/src/TreeView/types.ts
+++ b/src/TreeView/types.ts
@@ -33,7 +33,7 @@ export type EventCallback = <T, E>(
     metadata?: M;
   }
 
-  export interface INodeRendererProps<M extends IFlatMetadata> {
+  export interface INodeRendererProps<M extends IFlatMetadata = IFlatMetadata> {
     /** The object that represents the rendered node */
     element: INode<M>;
     /** A function which gives back the props to pass to the node */

--- a/src/TreeView/types.ts
+++ b/src/TreeView/types.ts
@@ -33,9 +33,9 @@ export type EventCallback = <T, E>(
     metadata?: M;
   }
 
-  export interface INodeRendererProps {
+  export interface INodeRendererProps<M extends IFlatMetadata> {
     /** The object that represents the rendered node */
-    element: INode;
+    element: INode<M>;
     /** A function which gives back the props to pass to the node */
     getNodeProps: (args?: {
       onClick?: EventCallback;

--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -307,7 +307,7 @@ export type IFlatMetadata = Record<
   string | number | boolean | undefined | null
 >;
 
-interface ITreeNode<M extends IFlatMetadata> {
+interface ITreeNode<M extends IFlatMetadata = IFlatMetadata> {
   id?: NodeId;
   name: string;
   isBranch?: boolean;
@@ -315,7 +315,7 @@ interface ITreeNode<M extends IFlatMetadata> {
   metadata?: M;
 }
 
-export const flattenTree = <M extends IFlatMetadata>(
+export const flattenTree = <M extends IFlatMetadata = IFlatMetadata>(
   tree: ITreeNode<M>
 ): INode<M>[] => {
   let internalCount = 0;
@@ -515,8 +515,8 @@ export const getOnSelectTreeAction = (
   return treeTypes.toggleSelect;
 };
 
-export const getTreeParent = (data: INode[]): INode => {
-  const parentNode: INode | undefined = data.find(
+export const getTreeParent = <M extends IFlatMetadata = IFlatMetadata>(data: INode<M>[]): INode<M> => {
+  const parentNode: INode<M> | undefined = data.find(
     (node) => node.parent === null
   );
 
@@ -527,7 +527,7 @@ export const getTreeParent = (data: INode[]): INode => {
   return parentNode;
 };
 
-export const getTreeNode = (data: INode[], id: NodeId): INode => {
+export const getTreeNode = <M extends IFlatMetadata = IFlatMetadata>(data: INode<M>[], id: NodeId): INode<M> => {
   const treeNode = data.find((node) => node.id === id);
 
   if (treeNode == null) {


### PR DESCRIPTION
This should provide type inference for `element.metadata`. I checked to see that the type was correct when passing metadata. However, I don't know too much about `propTypes` since I only really use typescript with React. Please let me know if there is any issues with this approach.

fixes #192 