### PR TITLE
Fix in controlled mode to ignore any id that not in data

### DIFF
--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -51,6 +51,10 @@ export const isBranchNode = (data: INode[], i: NodeId) => {
   return !!node.children?.length;
 };
 
+export const isNode = (data: INode[], id: NodeId) => {
+  return data.find((node) => node.id === id);
+};
+
 export const getBranchNodesToExpand = (data: INode[], id: NodeId): NodeId[] => {
   const parentId = getParent(data, id);
   const isNodeExpandable =
@@ -515,7 +519,9 @@ export const getOnSelectTreeAction = (
   return treeTypes.toggleSelect;
 };
 
-export const getTreeParent = <M extends IFlatMetadata = IFlatMetadata>(data: INode<M>[]): INode<M> => {
+export const getTreeParent = <M extends IFlatMetadata = IFlatMetadata>(
+  data: INode<M>[]
+): INode<M> => {
   const parentNode: INode<M> | undefined = data.find(
     (node) => node.parent === null
   );
@@ -527,7 +533,10 @@ export const getTreeParent = <M extends IFlatMetadata = IFlatMetadata>(data: INo
   return parentNode;
 };
 
-export const getTreeNode = <M extends IFlatMetadata = IFlatMetadata>(data: INode<M>[], id: NodeId): INode<M> => {
+export const getTreeNode = <M extends IFlatMetadata = IFlatMetadata>(
+  data: INode<M>[],
+  id: NodeId
+): INode<M> => {
   const treeNode = data.find((node) => node.id === id);
 
   if (treeNode == null) {

--- a/src/__tests__/ControlledExpandedNode.test.tsx
+++ b/src/__tests__/ControlledExpandedNode.test.tsx
@@ -286,4 +286,35 @@ describe("With node ids", () => {
     expect(nodesAfterExpandedAll[6]).toHaveAttribute("aria-expanded", "true");
     expect(nodesAfterExpandedAll[11]).toHaveAttribute("aria-expanded", "true");
   });
+  test("Should rerender when the data and expanded nodes change", () => {
+    const expandedIds = [1, 7, 11];
+
+    const { queryAllByRole, rerender } = render(
+      <ControlledExpanded expandedIds={expandedIds} data={dataWithoutIds} />
+    );
+
+    let nodes = queryAllByRole("treeitem");
+    expect(nodes.length).toBe(16);
+
+    // remove the fruits directory from both data and expandedIds
+    rerender(
+      <ControlledExpanded
+        expandedIds={[7, 11]}
+        data={dataWithoutIds
+          .filter((node) => node.id !== 1)
+          .map((node) => ({
+            ...node,
+            children: node.children.filter((child) => child !== 1),
+          }))}
+      />
+    );
+
+    nodes = queryAllByRole("treeitem");
+    // six nodes were removed (everything in fruits)
+    expect(nodes.length).toBe(10);
+
+    expect(nodes[0]).toHaveAttribute("aria-expanded", "true");
+    expect(nodes[1]).not.toHaveAttribute("aria-expanded");
+    expect(nodes[4]).toHaveAttribute("aria-expanded", "true");
+  });
 });

--- a/src/__tests__/ControlledTree.test.tsx
+++ b/src/__tests__/ControlledTree.test.tsx
@@ -599,6 +599,13 @@ describe("Data with ids", () => {
 
     const nodes = queryAllByRole("treeitem");
     expect(nodes[0]).toHaveAttribute("aria-checked", "true");
+    expect(nodes[1]).toHaveAttribute("aria-checked", "true");
+    expect(nodes[2]).toHaveAttribute("aria-checked", "true");
+    expect(nodes[3]).toHaveAttribute("aria-checked", "true");
+    expect(nodes[4]).toHaveAttribute("aria-checked", "true");
+    expect(nodes[5]).toHaveAttribute("aria-checked", "true");
+    expect(nodes[11]).toHaveAttribute("aria-checked", "true");
+    expect(nodes[18]).toHaveAttribute("aria-checked", "true");
   });
 
   test("SelectedIds should be re-rendered", () => {

--- a/src/__tests__/ControlledTree.test.tsx
+++ b/src/__tests__/ControlledTree.test.tsx
@@ -599,13 +599,6 @@ describe("Data with ids", () => {
 
     const nodes = queryAllByRole("treeitem");
     expect(nodes[0]).toHaveAttribute("aria-checked", "true");
-    expect(nodes[1]).toHaveAttribute("aria-checked", "true");
-    expect(nodes[2]).toHaveAttribute("aria-checked", "true");
-    expect(nodes[3]).toHaveAttribute("aria-checked", "true");
-    expect(nodes[4]).toHaveAttribute("aria-checked", "true");
-    expect(nodes[5]).toHaveAttribute("aria-checked", "true");
-    expect(nodes[11]).toHaveAttribute("aria-checked", "true");
-    expect(nodes[18]).toHaveAttribute("aria-checked", "true");
   });
 
   test("SelectedIds should be re-rendered", () => {
@@ -632,6 +625,26 @@ describe("Data with ids", () => {
     const newNodes = queryAllByRole("treeitem");
     expect(newNodes[11]).toHaveAttribute("aria-checked", "false");
     expect(newNodes[19]).toHaveAttribute("aria-checked", "true");
+  });
+
+  test("SelectedIds should not error when a selectedId are not in the data", () => {
+    const selectedId = ["data-string", "non-existent-id"];
+    expect(() => {
+      const { queryAllByRole } = render(
+        <MultiSelectCheckboxControlled
+          defaultExpandedIds={["data-string", "690", 908, 42]}
+          selectedIds={selectedId}
+          data={dataWithIds}
+        />
+      );
+      const nodes = queryAllByRole("treeitem");
+      expect(nodes[0]).toHaveAttribute("aria-checked", "true");
+      nodes.forEach((node, index) => {
+        if (index !== 0) {
+          expect(node).toHaveAttribute("aria-checked", "false");
+        }
+      });
+    }).not.toThrow(`Node with id=${selectedId[1]} doesn't exist in the tree.`);
   });
 
   test("SelectedIds should clear previous selection", () => {
@@ -753,16 +766,18 @@ describe("Data with ids", () => {
     expect(newNodes[4]).toHaveAttribute("aria-checked", "false");
     expect(newNodes[5]).toHaveAttribute("aria-checked", "false");
   });
-  
+
   test("SelectedIds should not steal focus if another control has it", () => {
     let selectedIds = [42];
-    const renderContent = (<div>
-      <input type="text" id="editor"/>
-      <MultiSelectCheckboxControlled
-        selectedIds={selectedIds}
-        data={dataWithIds}
-      />
-      </div>);
+    const renderContent = (
+      <div>
+        <input type="text" id="editor" />
+        <MultiSelectCheckboxControlled
+          selectedIds={selectedIds}
+          data={dataWithIds}
+        />
+      </div>
+    );
     const { rerender } = render(renderContent);
 
     const editorElement = document?.getElementById("editor");


### PR DESCRIPTION
To follow other tree view component patterns, we should ignore controlled selected and expanded id when they do not exist in the data as they can be removed. Only expand and select id that exist in data. If we don't it will errors since we expected to find it in the data when we render. 

Use solution in https://github.com/dgreene1/react-accessible-treeview/pull/174 but also included selected id. 