### PR TITLE
check existence of node during expand/collapse before acting on it

### DIFF
--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -269,7 +269,7 @@ const useTree = ({
           multiSelect,
         });
       for (const id of controlledSelectedIds) {
-        propagateSelect &&
+        propagateSelect && 
           !disabledIds.has(id) &&
           dispatch({
             type: treeTypes.changeSelectMany,
@@ -285,19 +285,19 @@ const useTree = ({
   useEffect(() => {
     const toggleControlledExpandedIds = new Set<NodeId>(controlledExpandedIds);
     //nodes need to be expanded
-    const diffExpandedIds = difference(
+    const diffExpandedIds = new Set<NodeId>([...difference(
       toggleControlledExpandedIds,
       prevExpandedIds
-    );
+    )].filter((id) => data.find((n) => n.id == id)));
     //nodes to be collapsed
-    const diffCollapseIds = difference(
+    const diffCollapseIds = new Set<NodeId>([...difference(
       prevExpandedIds,
       toggleControlledExpandedIds
-    );
+    )].filter((id) => data.find((n) => n.id == id)));
     //controlled collapsing
     if (diffCollapseIds.size) {
       for (const id of diffCollapseIds) {
-        if (data.find(d => d.id == id) && (isBranchNode(data, id) || getTreeNode(data, id).isBranch)) {
+        if (isBranchNode(data, id) || getTreeNode(data, id).isBranch) {
           const ids = [id, ...getDescendants(data, id, new Set<number>())];
           dispatch({
             type: treeTypes.collapseMany,

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -163,14 +163,16 @@ const useTree = ({
     const toggledExpandIds = symmetricDifference(expandedIds, prevExpandedIds);
     if (onExpand != null && onExpand !== noop) {
       for (const id of toggledExpandIds) {
-        onExpand({
-          element: getTreeNode(data, id),
-          isExpanded: expandedIds.has(id),
-          isSelected: selectedIds.has(id),
-          isDisabled: disabledIds.has(id),
-          isHalfSelected: halfSelectedIds.has(id),
-          treeState: state,
-        });
+        if(data.find(d => d.id == id)) {
+          onExpand({
+            element: getTreeNode(data, id),
+            isExpanded: expandedIds.has(id),
+            isSelected: selectedIds.has(id),
+            isDisabled: disabledIds.has(id),
+            isHalfSelected: halfSelectedIds.has(id),
+            treeState: state,
+          });
+        }
       }
     }
   }, [
@@ -295,7 +297,7 @@ const useTree = ({
     //controlled collapsing
     if (diffCollapseIds.size) {
       for (const id of diffCollapseIds) {
-        if (isBranchNode(data, id) || getTreeNode(data, id).isBranch) {
+        if (data.find(d => d.id == id) && (isBranchNode(data, id) || getTreeNode(data, id).isBranch)) {
           const ids = [id, ...getDescendants(data, id, new Set<number>())];
           dispatch({
             type: treeTypes.collapseMany,

--- a/src/TreeView/utils.ts
+++ b/src/TreeView/utils.ts
@@ -392,7 +392,7 @@ export const propagatedIds = (
 ) =>
   ids.concat(
     ...ids
-      .filter((id) => isBranchNode(data, id))
+      .filter((id) => data.find(d => d.id == id) && isBranchNode(data, id))
       .map((id) => getDescendants(data, id, disabledIds))
   );
 

--- a/src/__tests__/ControlledExpandedNode.test.tsx
+++ b/src/__tests__/ControlledExpandedNode.test.tsx
@@ -206,6 +206,25 @@ describe("Without node ids", () => {
     expect(nodesAfterExpandedAll[6]).toHaveAttribute("aria-expanded", "true");
     expect(nodesAfterExpandedAll[11]).toHaveAttribute("aria-expanded", "true");
   });
+  test("ExpandedIds should not throw if non-existent", () => {
+    const { queryAllByRole, rerender } = render(
+      <ControlledExpanded expandedIds={["does-not-exist"]} data={dataWithoutIds} />
+    );
+
+    const nodes = queryAllByRole("treeitem");
+    for(const node of nodes) {
+      expect(node).toHaveAttribute("aria-expanded", "false");
+    }
+
+    rerender(
+      <ControlledExpanded expandedIds={["does-not-exist-2"]} data={dataWithoutIds} />
+    );
+
+    const newNodes = queryAllByRole("treeitem");
+    for(const node of newNodes) {
+      expect(node).toHaveAttribute("aria-expanded", "false");
+    }
+  });
 });
 
 describe("With node ids", () => {
@@ -285,5 +304,24 @@ describe("With node ids", () => {
     expect(nodesAfterExpandedAll[0]).toHaveAttribute("aria-expanded", "true");
     expect(nodesAfterExpandedAll[6]).toHaveAttribute("aria-expanded", "true");
     expect(nodesAfterExpandedAll[11]).toHaveAttribute("aria-expanded", "true");
+  });
+  test("ExpandedIds should not throw if non-existent", () => {
+    const { queryAllByRole, rerender } = render(
+      <ControlledExpanded expandedIds={["does-not-exist"]} data={dataWithIds} />
+    );
+
+    const nodes = queryAllByRole("treeitem");
+    for(const node of nodes) {
+      expect(node).toHaveAttribute("aria-expanded", "false");
+    }
+
+    rerender(
+      <ControlledExpanded expandedIds={["does-not-exist-2"]} data={dataWithIds} />
+    );
+
+    const newNodes = queryAllByRole("treeitem");
+    for(const node of newNodes) {
+      expect(node).toHaveAttribute("aria-expanded", "false");
+    }
   });
 });

--- a/src/__tests__/ControlledTree.test.tsx
+++ b/src/__tests__/ControlledTree.test.tsx
@@ -585,6 +585,21 @@ describe("Data without ids", () => {
     expect(getNodes()[0]).toHaveAttribute("aria-checked", "false");
     expect(getNodes()[1]).toHaveAttribute("aria-checked", "false");
   });
+  test("SelectedIds should not throw if non-existent", () => {
+    const { queryAllByRole } = render(
+
+      <MultiSelectCheckboxControlled
+        defaultExpandedIds={[]}
+        selectedIds={["does-not-exist"]}
+        data={dataWithoutIds}
+      />
+    );
+
+    const nodes = queryAllByRole("treeitem");
+    for(const node of nodes) {
+      expect(node).toHaveAttribute("aria-checked", "false");
+    }
+  });
 });
 
 describe("Data with ids", () => {
@@ -800,5 +815,21 @@ describe("Data with ids", () => {
     expect(newNodes[4]).toHaveAttribute("aria-checked", "true"); // Drinks->Coffee
     expect(newNodes[5]).toHaveAttribute("aria-checked", "true"); // Drinks->Tea
     expect(newNodes[6]).toHaveAttribute("aria-checked", "false"); // Vegetables
+  });
+
+  test("SelectedIds should not throw if non-existent", () => {
+    const { queryAllByRole } = render(
+
+      <MultiSelectCheckboxControlled
+        defaultExpandedIds={["data-string", "690", 908, 42]}
+        selectedIds={["does-not-exist"]}
+        data={dataWithIds}
+      />
+    );
+
+    const nodes = queryAllByRole("treeitem");
+    for(const node of nodes) {
+      expect(node).toHaveAttribute("aria-checked", "false");
+    }
   });
 });


### PR DESCRIPTION
Recreate of #216.
@dgreene1 , sorry for the churn but I couldn't figure out how to update the other MR.  

update handling of expanding/collapsing nodes to ensure they exist in the tree

addresses https://github.com/dgreene1/react-accessible-treeview/issues/191