### PR TITLE
Fix propagateSelect for when defaultSelectId is set.   

### DIFF
--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -260,10 +260,8 @@ const useTree = ({
 
   useEffect(() => {
     const selectedIdsToUse = controlledSelectedIds || defaultSelectedIds;
-    const isControlledSelected =
-      controlledSelectedIds && controlledSelectedIds.length > 0;
 
-    if (isControlledSelected) {
+    if (!!controlledSelectedIds) {
       toggledControlledIds.size &&
         dispatch({
           type: treeTypes.controlledSelectMany,

--- a/src/TreeView/index.tsx
+++ b/src/TreeView/index.tsx
@@ -259,14 +259,21 @@ const useTree = ({
   );
 
   useEffect(() => {
-    if (!!controlledSelectedIds) {
+    const selectedIdsToUse = controlledSelectedIds || defaultSelectedIds;
+    const isControlledSelected =
+      controlledSelectedIds && controlledSelectedIds.length > 0;
+
+    if (isControlledSelected) {
       toggledControlledIds.size &&
         dispatch({
           type: treeTypes.controlledSelectMany,
           ids: controlledSelectedIds,
           multiSelect,
         });
-      for (const id of controlledSelectedIds) {
+    }
+
+    if (selectedIdsToUse) {
+      for (const id of selectedIdsToUse) {
         propagateSelect &&
           !disabledIds.has(id) &&
           dispatch({


### PR DESCRIPTION
- Issue: when defaultSelectId is set with propagateSelect, the children are not set.